### PR TITLE
mkdocs: fix edit_uri to point to main branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Ubuntu Cloud Documentations
 repo_url: https://github.com/canonical/ubuntu-cloud-docs
+edit_uri: edit/main/docs/
 site_dir: public
 use_directory_urls: false
 theme:


### PR DESCRIPTION
By default, mkdocs assumes that the default branch is master and not
main. This is fixed here.

[0] https://www.mkdocs.org/user-guide/configuration/#edit_uri