### PR TITLE
fix: drop release from conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -11,7 +11,6 @@ import datetime
 project = 'Public Cloud'
 author = 'Canonical Group Ltd'
 copyright = "%s, %s" % (datetime.date.today().year, author)
-release = '0.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
With that, the documentation title does no longer contain "0.1". That information doesn't belong to the title and 0.1 doesn't help at all anyway.
Dropping the variable does adjust the title[0].

Refs:
- [0] https://pradyunsg.me/furo/customisation/sidebar-title/