### PR TITLE
docs(azure): azure cvm and trusted launch revisions

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -46,3 +46,9 @@ UI
 UUID
 VM
 YAML
+az
+vm
+URN
+URNs
+sku
+skus

--- a/azure/azure-explanation/confidential-computing.rst
+++ b/azure/azure-explanation/confidential-computing.rst
@@ -3,16 +3,16 @@ Security features on Azure
 
 Azure provides two types of security features:
 
-* `Trusted launch <https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch>`_ which is a set of features including virtual Trusted Platform Module (vTPM) and `secure boot <https://wiki.ubuntu.com/UEFI/SecureBoot>`_
+* `Trusted Launch <https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch>`_ which is a set of features including virtual Trusted Platform Module (vTPM) and `secure boot <https://wiki.ubuntu.com/UEFI/SecureBoot>`_
 * `Confidential virtual machine <https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview>`_ with support for `AMD Secure Encrypted Virtualisation-Secure Nested Paging (SEV-SNP) <https://www.amd.com/system/files/TechDocs/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf>`_, along with `measured boot <https://learn.microsoft.com/en-us/azure/security/fundamentals/measured-boot-host-attestation>`_ using a vTPM
+
+See :ref:`Launch Ubuntu Images on Azure` on how to launch Ubuntu images with Trusted Launch and
+Confidential Virtual Machine on Azure.
 
 Trusted launch
 --------------
 
 All Ubuntu images from 20.04 (Focal Fossa) support trusted launch and secure boot on Hyper-V Gen2 instances. 
-To start an Ubuntu instance with vTPM and secure boot enabled, use the following flags from the Azure CLI::
-        
-   --security-type TrustedLaunch --enable-secure-boot true --enable-vtpm
 
 Confidential VM
 ---------------
@@ -29,14 +29,10 @@ In short, a confidential VM is a combination of two features:
 
 It's important to note that memory encryption is always enabled with a confidential VM, but FDE is optional and requires explicit activation after the VM is provisioned.
 
-
 Using Ubuntu on confidential VMs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Confidential VMs require the use of special instance sizes and a special version of Ubuntu.
+Currently there are two Ubuntu images which support Confidential VMs:
 
-* A list of instance sizes that can be used for confidential VMs is given in `Azure's documentation <https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview>`_ 
-* Only `this specific offer of Ubuntu <https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal>`_ supports confidential VMs.
-
-
-   
+* Ubuntu CVM 20.04 LTS, which supports SEV-SNP
+* Ubuntu CVM 22.04 LTS, which supports SEV-SNP - as well as Intel TDX which is still in Public Preview and has yet to reach General Availability.

--- a/azure/azure-how-to/index.rst
+++ b/azure/azure-how-to/index.rst
@@ -5,6 +5,7 @@ Launching and using Ubuntu instances:
 
 * :doc:`Install Azure CLI <instances/install-azure-cli>`
 * :doc:`Find images <instances/find-ubuntu-images>`
+* :doc:`Launch images <instances/launch-ubuntu-images>`
 * :doc:`Get Ubuntu Pro <instances/get-ubuntu-pro>`
 * :doc:`Create a Pro golden image <instances/create-pro-fips-golden-image>`
 * :doc:`Upgrade from Focal to Jammy <instances/upgrade-from-focal-to-jammy>`

--- a/azure/azure-how-to/instances/index.rst
+++ b/azure/azure-how-to/instances/index.rst
@@ -6,6 +6,7 @@ Compute instances
 
    Install Azure CLI <install-azure-cli>
    Find images <find-ubuntu-images>
+   Launch images <launch-ubuntu-images>
    Get Ubuntu Pro <get-ubuntu-pro>
    Create Pro golden image <create-pro-fips-golden-image>
    Upgrade from Focal to Jammy <upgrade-from-focal-to-jammy>

--- a/azure/azure-how-to/instances/launch-ubuntu-images.rst
+++ b/azure/azure-how-to/instances/launch-ubuntu-images.rst
@@ -1,0 +1,124 @@
+Launch Ubuntu Images on Azure
+=============================
+
+This documentation is based on the `official Azure documentation <https://learn.microsoft.com/en-us/azure/virtual-machines/linux/quick-create-cli>`_
+for creating Linux virtual machines with the Azure CLI.
+
+Prerequisites
+-------------
+
+- A Microsoft Azure account
+- `Azure Command-Line Interface <https://learn.microsoft.com/en-us/cli/azure/>`_
+- The URN for a Ubuntu image on Azure to launch (see :ref:`Find Ubuntu images on Azure`)
+
+Launch a Ubuntu Image
+---------------------
+
+To launch a Ubuntu Image, you will need to create a resource group and create a virtual machine using the Ubuntu image
+you have selected.
+
+Create the Resource Group
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Define variables to select the resource group name and location to deploy:
+
+.. code::
+
+    RESOURCE_GROUP_NAME="ubuntu-vm-rg"
+    LOCATION="eastus"
+
+Create a resource group using the `az group create <https://learn.microsoft.com/en-us/cli/azure/group?view=azure-cli-latest#az-group-create>`_ command:
+
+.. code::
+
+    az group create \
+        -n $RESOURCE_GROUP_NAME \
+        -l $LOCATION
+
+Create the Virtual Machine
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a virtual machine using the `az vm create <https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create>`_ command.
+
+Depending on the type of Ubuntu image you have selected, additional arguments may be required to correctly launch
+the image. Most Ubuntu images can be launched with the default arguments:
+
+.. code::
+
+    az vm create \
+        --name $VIRTUAL_MACHINE_NAME \
+        --resource-group $RESOURCE_GROUP_NAME \
+        --image $UBUNTU_IMAGE_URN \
+        --generate-ssh-keys
+
+Security Type - Trusted Launch
+++++++++++++++++++++++++++++++
+
+All Ubuntu images from Ubuntu 20.04 LTS (Focal Fossa) forward support Trusted Launch on Hyper-V Gen2 skus. Example
+definitions of Ubuntu image URNs for Hyper-V Gen2 include:
+
+.. code::
+
+    UBUNTU_IMAGE_URN="Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+    # or
+    UBUNTU_IMAGE_URN="Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
+
+Define the variables to select the security type:
+
+.. code::
+
+    SECURITY_TYPE=TrustedLaunch
+
+Create the virtual machine:
+
+.. code::
+
+    az vm create \
+        --name $VIRTUAL_MACHINE_NAME \
+        --resource-group $RESOURCE_GROUP_NAME \
+        --image $UBUNTU_IMAGE_URN \
+        --security-type $SECURITY_TYPE \
+        --generate-ssh-keys
+
+Security Type - Confidential Virtual Machine
+++++++++++++++++++++++++++++++++++++++++++++
+
+Select one of the two URNs for Ubuntu images which support CVM on Azure:
+
+.. code::
+
+    UBUNTU_IMAGE_URN="Canonical:0001-com-ubuntu-confidential-vm-jammy:22_04-lts-cvm:latest"
+    # or
+    UBUNTU_IMAGE_URN="Canonical:0001-com-ubuntu-confidential-vm-focal:20_04-lts-cvm:latest"
+
+Define variables to select the security type and encryption type:
+
+.. code::
+
+    SECURITY_TYPE=ConfidentialVm
+    OS_ENCRYPTION_TYPE=DiskWithVMGuestState
+
+Select a virtual machine size which `supports CVM on Azure <https://learn.microsoft.com/en-us/azure/confidential-computing/virtual-machine-solutions#sizes>`_.
+Note that not all regions will contain the selected virtual machine size, and you may need to specify the region if
+your default region does not have the selected size:
+
+.. code::
+
+    VM_SIZE=Standard_DC2as_v5
+
+    # Standard_DC2as_v5 is available on eastus
+    LOCATION=eastus
+
+Create the virtual machine:
+
+.. code::
+
+    az vm create \
+        --name $VIRTUAL_MACHINE_NAME \
+        --resource-group $RESOURCE_GROUP_NAME \
+        --image $UBUNTU_IMAGE_URN \
+        --security-type $SECURITY_TYPE \
+        --os-disk-security-encryption-type $OS_ENCRYPTION_TYPE \
+        --size $VM_SIZE \
+        --location $LOCATION \
+        --generate-ssh-keys


### PR DESCRIPTION
Per [0], created dedicated documentation for launching Ubuntu CVM images on Azure. Given there was no documentation for launching Ubuntu images on Azure in general, de-duplicated the Azure CLI launch instructions for Trusted Launch in the confidential computing document. Also refined the Azure CLI commands as it applies to Trusted Launch (e.g. selecting the TrustedLaunch security type will automatically enable vTPM).

Also normalized proper noun capitalization for references to Trusted Launch and Confidential Virtual Machines. Although the capitalization in Azure documentation can also be inconsistent at times, given these security features are discretely named (Standard, Trusted Launch, and Confidential Virtual Machine) - distinguishing them from regular prose aids readability.

References:

[0] https://warthogs.atlassian.net/browse/CPC-3283