### PR TITLE
fix(gce): Add jammy to list of upgrade URIs

### DIFF
--- a/google/google-how-to/gce/upgrade-in-place-from-lts-to-pro.rst
+++ b/google/google-how-to/gce/upgrade-in-place-from-lts-to-pro.rst
@@ -33,7 +33,8 @@ where,
      - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-1804-lts``
    * - Ubuntu Pro 20.04 LTS
      - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2004-lts``
-    
+   * - Ubuntu Pro 22.04 LTS
+     - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2204-lts``
 
 
 3. Start the machine


### PR DESCRIPTION
In preparing for noble release, I noticed that we do not have jammy listed on the LTS-to-pro upgrade path documentation.