### PR TITLE
docs: restructure and apply diataxis to OCI docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _build
 .DS_Store
 __pycache__
 .idea/
+oci/_external/*.rst
+.vscode

--- a/all-clouds/index.rst
+++ b/all-clouds/index.rst
@@ -24,12 +24,11 @@ For further details, refer to the cloud-specific documentation:
 ..  grid:: 1 1 2 2
    :padding: 0
 
-   .. grid-item:: :doc:`Ubuntu on AWS <aws:index>`    
-   .. grid-item:: :doc:`Ubuntu on GCP <google:index>` 
-   .. grid-item:: :doc:`Ubuntu on IBM <ibm:index>`
-   .. grid-item:: :doc:`Ubuntu on Azure <azure:index>`
-   .. grid-item:: :doc:`Ubuntu on Oracle <oracle:index>`
-   .. grid-item:: :doc:`Ubuntu on OCI registries<oci:index>` 
+   .. grid-item-card:: :doc:`Ubuntu on AWS <aws:index>`   
+   .. grid-item-card:: :doc:`Ubuntu on Azure <azure:index>`  
+   .. grid-item-card:: :doc:`Ubuntu on GCP <google:index>` 
+   .. grid-item-card:: :doc:`Ubuntu on IBM <ibm:index>` 
+   .. grid-item-card:: :doc:`Ubuntu on Oracle <oracle:index>`
 
 
 

--- a/aws/aws-how-to/instances/find-ubuntu-images.rst
+++ b/aws/aws-how-to/instances/find-ubuntu-images.rst
@@ -79,23 +79,17 @@ If you don't want to save the AMI ID before instantiating the image, you can use
 Ownership verification
 ~~~~~~~~~~~~~~~~~~~~~~
 
-By checking the `OwnerId` field of an image, users can verify that an AMI was published by Canonical. The expected value for Canonical is one of the following:
+By checking the `OwnerId` field of an image, you can verify that an AMI was published by Canonical. To do this, use the `describe-images` command against an AMI ID and check the returned `OwnerId` field:
+
+.. code::
+
+   aws ec2 describe-images --image-ids $AMI_ID
+
+The expected value of `OwnerId` for Canonical is one of the following:
 
 * `099720109477` (in the default partition)
 * `513442679011` (in the GovCloud partition)
 * `837727238323` (in the China partition)
-
-This value/ID is stored in SSM as the publisher-id and can be found by running:
-
-.. code-block::
-
-   aws ssm get-parameters --names /aws/service/canonical/meta/publisher-id
-
-Users can then run the `describe-images` command against an AMI ID and verify that the `OwnerId` field matches the ID returned from the above command.
-
-.. code-block::
-
-   aws ec2 describe-images --image-ids $AMI_ID
 
 Note that listings on the AWS Marketplace will always show the `OwnerId` as Amazon (e.g. `679593333241`). In these cases, users can verify the Amazon ID and look for `aws-marketplace/ubuntu` in the `ImageLocation` field.
 

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -161,9 +161,9 @@ custom_linkcheck_anchors_ignore_for_url = []
 # NOTE: Remove this variable to disable the MyST parser extensions.
 custom_myst_extensions = []
 
-# Add custom Sphinx extensions as needed. 
+# Add custom Sphinx extensions as needed.
 # This array contains recommended extensions that should be used.
-# NOTE: The following extensions are handled automatically and do 
+# NOTE: The following extensions are handled automatically and do
 # not need to be added here: myst_parser, sphinx_copybutton, sphinx_design,
 # sphinx_reredirects, sphinxcontrib.jquery, sphinxext.opengraph
 custom_extensions = [
@@ -202,7 +202,7 @@ multiproject_projects = {
     "google": {},
     "ibm": {},
     "oracle": {},
-    "oci": {}
+    "oci": {},
 }
 
 intersphinx_mapping = {

--- a/oci/conf.py
+++ b/oci/conf.py
@@ -1,51 +1,59 @@
+import pathlib
+import urllib.request
+
 # Configuration file for the Sphinx documentation builder.
-project = 'Ubuntu on OCI Registries'
+project = "Ubuntu on OCI Container Registries"
 
 # The title you want to display for the documentation in the sidebar.
 # You might want to include a version number here.
 # To not display any title, set this option to an empty string.
-html_title = project + ' documentation'
+html_title = project + " documentation"
 
-# Some settings in the html_context dictionary have to be repeated 
+# Some settings in the html_context dictionary have to be repeated
 # in the sub projects for correct functioning (don't remove them)
 html_context = {
-
     # Add your product tag (the orange part of your logo, will be used in the
     # header) to ".sphinx/_static" and change the path here (start with "_static")
     # (default is the circle of friends)
-    'product_tag': '_static/tag.png',
-
+    "product_tag": "_static/tag.png",
     # Change to the discourse instance you want to be able to link to
     # using the :discourse: metadata at the top of a file
     # (use an empty value if you don't want to link)
-    'discourse': 'https://discourse.ubuntu.com/c/public-cloud/',
-
+    "discourse": "https://discourse.ubuntu.com/c/public-cloud/",
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
-
+    "mattermost": "https://chat.canonical.com/canonical/channels/public-cloud-eng",
     # Change to the GitHub URL for your project
-    'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
-
+    "github_url": "https://github.com/canonical/ubuntu-cloud-docs",
     # Change to the branch for this version of the documentation
-    'github_version': 'main',
-
+    "github_version": "main",
     # Change to the folder that contains the documentation
     # (usually "/" or "/docs/")
-    'github_folder': '/oci/',
-
+    "github_folder": "/oci/",
     # Change to an empty value if your GitHub repo doesn't have issues enabled.
     # This will disable the feedback button and the issue link in the footer.
-    'github_issues': 'enabled',
-
-    # Change to the folder that contains the documentation 
+    "github_issues": "enabled",
+    # Change to the folder that contains the documentation
     # (usually "/" or "/docs/")
-    "conf_py_path": '/oci/',
-
+    "conf_py_path": "/oci/",
     # Controls the existence of Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
     # You can override the default setting on a page-by-page basis by specifying
     # it as file-wide metadata at the top of the file, see
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
-    'sequential_nav': "both"
+    "sequential_nav": "both",
 }
+
+# These docs reuse some content from other docs
+pro_client_docs = {
+    "enable-pro-services.rst": "https://raw.githubusercontent.com/canonical/ubuntu-pro-client/docs/docs/howtoguides/enable_in_dockerfile.rst",
+    "create-fips-container-image.rst": "https://raw.githubusercontent.com/canonical/ubuntu-pro-client/docs/docs/tutorials/create_a_fips_docker_image.rst",
+}
+common_docs_path = pathlib.Path(__file__).parent / "_external"
+exclude_patterns = ["_external"]
+for page in pro_client_docs:
+    urllib.request.urlretrieve(
+        pro_client_docs[page],
+        common_docs_path / page,
+    )
+    # exclude_patterns.append(str(common_docs_path / page))

--- a/oci/conf.py
+++ b/oci/conf.py
@@ -2,7 +2,7 @@ import pathlib
 import urllib.request
 
 # Configuration file for the Sphinx documentation builder.
-project = "Ubuntu on OCI Container Registries"
+project = "Ubuntu on OCI container registries"
 
 # The title you want to display for the documentation in the sidebar.
 # You might want to include a version number here.

--- a/oci/index.rst
+++ b/oci/index.rst
@@ -1,82 +1,64 @@
-Ubuntu on OCI Registries
-========================
+Ubuntu on OCI container registries
+==================================
 
-The Open Container Initiative (OCI) establishes standards for constructing container 
-images that can be reliably installed across a variety of compliant host environments.
+**Ubuntu is one of the world's most popular container images.** A minimalistic Ubuntu image that offers the same security, versatility, and update cadence as other Ubuntu offerings. A developer favourite in container registries such as Docker Hub, with up to 30,000 pulls per week.
 
-Ubuntu’s `LTS Docker Image Portfolio <https://ubuntu.com/security/docker-images>`_ 
-provides OCI-compliant images that receive stable security updates and predictable 
-software updates, thus ensuring consistency in both maintenance schedule and operational 
-interfaces for the underlying software your software builds on.
+**Available in all major OCI container registries,** such as Microsoft's ACR, Amazon's ECR, and of course, Docker Hub, as an official image from a verified publisher - Canonical. 
 
-Ubuntu OCI tarball is a minimal rootfs tarball ready for use to build OCI/Docker 
-container base images. It is similar to `Ubuntu Base <https://wiki.ubuntu.com/Base>`_ 
-but already contains the modifications needed to make the rootfs suitable for 
-building OCI/Docker container images. It is available for the amd64, armhf, arm64, 
-powerpc and ppc64el architectures. The rootfs tarballs are published under 
-`OCI partner images <https://partner-images.canonical.com/oci/>`_. 
+**A base container for trusted application images.** Container image provenance is a key aspect of any supply chain. The Ubuntu container image offers the ideal starting point for your application images, both in utility and trustworthiness.
 
-Canonical publishes official Docker images to Docker Hub based on OCI images that are 
-built from the Ubuntu OCI rootfs tarballs. Images are also published to AWS ECR 
-(Elastic Container Registry) gallery (in `ubuntu <https://gallery.ecr.aws/ubuntu/ubuntu>`_
-and `lts <https://gallery.ecr.aws/lts/ubuntu>`_ namespaces), ACR (Azure Container Registry),
-OCIR (Oracle Container Infrastructure Registry), and there are plans to publish to more
-registries in the future.
+**Compatible with multiple platforms and available in different flavours.** The Ubuntu container image is published as a multi-arch OCI (Open Container Initiative) image that is available for ``amd64``, ``arm``, ``arm64``, ``ppc64le`` and ``s390x``. Moreover, Ubuntu Pro is also available for containers, which means hardened and security-enhanced versions of the public Ubuntu container image are also available.
 
-
-----------
-
-.. _building_ubuntu_pro_oci_images:
-
-Building Ubuntu Pro OCI images
-------------------------------
-
-Similar to the `Ubuntu Pro images in public clouds <https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/what_are_ubuntu_pro_cloud_instances/>`_, one can build an Ubuntu Pro OCI image to leverage services like ESM (Extended Security Maintenance) and FIPS.
-
-The easiest way to build an Ubuntu Pro container image is to make use of existing container management tools (like Docker) and enable the Pro services on top of an existing Ubuntu container image (e.g. `ubuntu:focal <https://hub.docker.com/layers/library/ubuntu/focal/images/sha256-b39db7fc56971aac21dee02187e898db759c4f26b9b27b1d80b6ad32ff330c76?context=explore>`_).
-
-.. note::
-   It is highly recommended that Ubuntu Pro container images should be built on hosts that are already covered by an Ubuntu Pro subscription.
-
-This process is described in detail in the `pro client documentation <https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/enable_in_dockerfile/>`_. The resulting Ubuntu Pro container image can then be loaded into your local Docker daemon (by using ``--load`` when running ``docker build``) and can be deployed/published normally as any other container image.
-
-
-----------
-
-How-to guides
--------------
-
-Instructions for deploying Ubuntu Pro containers on Kubernetes and for creating a 'chiselled' Ubuntu base image are linked below:
-
-* :doc:`Deploy Pro containers on K8s <./oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster>`
-* :doc:`Create a chiselled image <./oci-how-to/create-chiselled-ubuntu-image>`
-
-
----------
-
-Project and community
----------------------
-
-Ubuntu on OCI registries is a member of the Ubuntu family and the project warmly welcomes 
-community projects, contributions, suggestions, fixes and constructive feedback.
-
-* `Get support`_
-* `Join our online chat`_
-* `Discuss on IRC`_
-* :doc:`oci-how-to/contribute-to-these-docs`
-* `Code of conduct`_
 
 .. toctree::
+   :maxdepth: 1
    :hidden:
-   :maxdepth: 2
 
-   Deploy Pro containers on K8s <oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster>
-   Create a chiselled image <oci-how-to/create-chiselled-ubuntu-image>
-   oci-how-to/contribute-to-these-docs
+   oci-tutorials/index
+   oci-how-to/index
+   oci-reference/index
+   oci-explanation/index
 
-  
-.. _Get support: https://ubuntu.com/cloud/public-cloud
-.. _Join our online chat: https://discourse.ubuntu.com/c/public-cloud/176
-.. _`Discuss on IRC`: https://web.libera.chat/#ubuntu-cloud
-.. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
 
+.. grid:: 1 1 2 2
+
+   .. grid-item-card:: :ref:`Tutorials <oci-tutorials>`
+
+      **Get started** - become familiar with the Ubuntu container image and its
+      common usage.
+
+   .. grid-item-card:: :ref:`How-to guides <oci-how-to>`
+
+      **Step-by-step guides** - learn how to use the Ubuntu container image to
+      achieve a goal, like :ref:`deploying a Pro container
+      image to a Pro Kubernetes cluster
+      <how-to-deploy-pro-container-on-pro-cluster>`.
+
+.. grid:: 1 1 2 2
+   :padding: 0
+   :reverse:
+
+   .. grid-item-card:: :ref:`Reference <oci-reference>`
+
+      **Technical information** - understand the Ubuntu container images'
+      design and where you can get them from.
+
+   .. grid-item-card:: :ref:`Explanation <oci-explanation>`
+
+      **Discussion and clarification** - dive a bit deeper into what Ubuntu and
+      Ubuntu Pro container images are.
+
+
+Project and community
+=====================
+
+This project is a member of the Ubuntu family and it warmly welcomes community
+projects, contributions, suggestions, fixes, and constructive feedback.
+
+* `Get support <https://ubuntu.com/cloud/public-cloud>`_
+* `Join our online chat <https://discourse.ubuntu.com/c/public-cloud/176>`_
+* `Discuss on IRC <https://web.libera.chat/#ubuntu-cloud>`_
+* `Ubuntu Docker Images on Launchpad <https://launchpad.net/ubuntu-docker-images>`_
+* `Ubuntu Code of Conduct <https://ubuntu.com/community/code-of-conduct>`_
+* `Canonical contributor license agreement
+  <https://ubuntu.com/legal/contributors>`_

--- a/oci/index.rst
+++ b/oci/index.rst
@@ -1,7 +1,7 @@
 Ubuntu on OCI container registries
 ==================================
 
-**Ubuntu is one of the world's most popular container images.** A minimalistic Ubuntu image that offers the same security, versatility, and update cadence as other Ubuntu offerings. A developer favourite in container registries such as Docker Hub, with up to 30,000 pulls per week.
+**Ubuntu is one of the world's most popular container images,** a minimalistic Ubuntu image that offers the same security, versatility, and update cadence as other Ubuntu offerings. It is a developer favourite in container registries such as Docker Hub, with up to 30,000 pulls per week.
 
 **Available in all major OCI container registries,** such as Microsoft's ACR, Amazon's ECR, and of course, Docker Hub, as an official image from a verified publisher - Canonical. 
 
@@ -30,7 +30,7 @@ Ubuntu on OCI container registries
    .. grid-item-card:: :ref:`How-to guides <oci-how-to>`
 
       **Step-by-step guides** - learn how to use the Ubuntu container image to
-      achieve a goal, like :ref:`deploying a Pro container
+      achieve specific goals, like :ref:`deploying a Pro container
       image to a Pro Kubernetes cluster
       <how-to-deploy-pro-container-on-pro-cluster>`.
 
@@ -40,8 +40,8 @@ Ubuntu on OCI container registries
 
    .. grid-item-card:: :ref:`Reference <oci-reference>`
 
-      **Technical information** - understand the Ubuntu container images'
-      design and where you can get them from.
+      **Technical information** - understand the design of Ubuntu container images
+      and where you can get them from.
 
    .. grid-item-card:: :ref:`Explanation <oci-explanation>`
 

--- a/oci/links.txt
+++ b/oci/links.txt
@@ -1,0 +1,2 @@
+.. _Pro: https://ubuntu.com/pro
+.. _Ubuntu One: https://login.ubuntu.com/

--- a/oci/oci-explanation/index.rst
+++ b/oci/oci-explanation/index.rst
@@ -4,7 +4,7 @@
 Explanation
 ***********
 
-This section of the documentation covers the definitions of the Ubuntu and
+Here you'll find the definitions of the Ubuntu and
 Ubuntu Pro container images.
 
 .. toctree::

--- a/oci/oci-explanation/index.rst
+++ b/oci/oci-explanation/index.rst
@@ -1,0 +1,14 @@
+.. _oci-explanation:
+
+***********
+Explanation
+***********
+
+This section of the documentation covers the definitions of the Ubuntu and
+Ubuntu Pro container images.
+
+.. toctree::
+   :maxdepth: 1
+
+   ubuntu-oci-container
+   ubuntu-pro-oci-container

--- a/oci/oci-explanation/ubuntu-oci-container.rst
+++ b/oci/oci-explanation/ubuntu-oci-container.rst
@@ -11,9 +11,9 @@ provides OCI-compliant images that receive stable security updates and predictab
 software updates, ensuring consistency in both maintenance schedule and operational 
 interfaces for the underlying foundation your software builds on.
 
-Moreover, `Ubuntu-based containers <https://ubuntu.com/containers>`_ (like
+Moreover, all `Ubuntu-based containers <https://ubuntu.com/containers>`_ (like
 `chiselled container images <https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/chisel/>`_)
-all leverage the Ubuntu container image as their
+leverage the Ubuntu container image as their
 starting point, and so also benefit from its
 `support and security commitments <https://ubuntu.com/security/docker-images>`_.
 

--- a/oci/oci-explanation/ubuntu-oci-container.rst
+++ b/oci/oci-explanation/ubuntu-oci-container.rst
@@ -1,0 +1,22 @@
+.. _ubuntu-oci-container-images:
+
+Ubuntu OCI container images
+===========================
+
+The Open Container Initiative (OCI) establishes standards for constructing container 
+images that can be reliably installed across a variety of compliant host environments.
+
+Ubuntu’s `LTS Docker Image Portfolio <https://ubuntu.com/security/docker-images>`_ 
+provides OCI-compliant images that receive stable security updates and predictable 
+software updates, thus ensuring consistency in both maintenance schedule and operational 
+interfaces for the underlying software your software builds on.
+
+Moreover, `Ubuntu-based containers <https://ubuntu.com/containers>`_ (like
+chiselled container images) all leverage the Ubuntu container image as their
+starting point, and thus also profit from its support and security commitments.
+
+The Ubuntu container image is built from a minimal rootfs tarball. This tarball
+is similar to `Ubuntu Base <https://wiki.ubuntu.com/Base>`_ 
+but it already contains the modifications needed to make the rootfs suitable for 
+building OCI/Docker container images. The Ubuntu OCI rootfs tarballs are published
+in `OCI partner images <https://partner-images.canonical.com/oci/>`_. 

--- a/oci/oci-explanation/ubuntu-oci-container.rst
+++ b/oci/oci-explanation/ubuntu-oci-container.rst
@@ -9,14 +9,15 @@ images that can be reliably installed across a variety of compliant host environ
 Ubuntu’s `LTS Docker Image Portfolio <https://ubuntu.com/security/docker-images>`_ 
 provides OCI-compliant images that receive stable security updates and predictable 
 software updates, thus ensuring consistency in both maintenance schedule and operational 
-interfaces for the underlying software your software builds on.
+interfaces for the underlying foundation your software builds on.
 
 Moreover, `Ubuntu-based containers <https://ubuntu.com/containers>`_ (like
-chiselled container images) all leverage the Ubuntu container image as their
-starting point, and thus also profit from its support and security commitments.
+`chiselled container images <https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/chisel/>`_)
+all leverage the Ubuntu container image as their
+starting point, and so also benefit from its
+`support and security commitments <https://ubuntu.com/security/docker-images>`_.
 
 The Ubuntu container image is built from a minimal rootfs tarball. This tarball
-is similar to `Ubuntu Base <https://wiki.ubuntu.com/Base>`_ 
-but it already contains the modifications needed to make the rootfs suitable for 
+already contains the modifications needed to make the rootfs suitable for 
 building OCI/Docker container images. The Ubuntu OCI rootfs tarballs are published
 in `OCI partner images <https://partner-images.canonical.com/oci/>`_. 

--- a/oci/oci-explanation/ubuntu-pro-oci-container.rst
+++ b/oci/oci-explanation/ubuntu-pro-oci-container.rst
@@ -1,0 +1,17 @@
+.. _ubuntu-pro-oci-container-images:
+
+Ubuntu Pro OCI container images
+===============================
+
+
+Similar to the `Ubuntu Pro images in public clouds
+<https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/what_are_ubuntu_pro_cloud_instances/>`_, one can build an Ubuntu Pro container image to leverage services like ESM
+(Extended Security Maintenance) and FIPS.
+
+The easiest way to build an Ubuntu Pro container image is to make use of existing container management tools (like Docker) and enable the Pro services on top of an existing Ubuntu container image (e.g. `ubuntu:focal <https://hub.docker.com/_/ubuntu/tags?page=&page_size=&ordering=&name=focal>`_).
+
+.. note::
+   Ubuntu Pro container images should be run on hosts that are already covered by an Ubuntu Pro subscription.
+   Please consult the `Ubuntu Pro service description <https://ubuntu.com/legal/ubuntu-pro>`_ for more details.
+
+This process is described in detail in :ref:`this How-to guide <oci-how-to-enable-pro-services>`. The resulting Ubuntu Pro container image can then be loaded into your local Docker daemon and/or can be deployed normally as any other container image.

--- a/oci/oci-how-to/contribute-to-these-docs.rst
+++ b/oci/oci-how-to/contribute-to-these-docs.rst
@@ -13,7 +13,7 @@ Contribute to these docs
 
 	PROJECT=oci make run
 
-Setting the `PROJECT` parameter to ``oci`` ensures that the documentation set for `Ubuntu on Container Registries` gets built. This parameter is needed to distinguish between the different documentation sets present in the repository.
+Setting the `PROJECT` parameter to ``oci`` ensures that the documentation set for `Ubuntu on OCI container registries` gets built. This parameter is needed to distinguish between the different documentation sets present in the repository.
 
 .. include:: ../../reuse/contribute-to-docs.txt
    :start-after: Start: How to contribute (continued)

--- a/oci/oci-how-to/contribute-to-these-docs.rst
+++ b/oci/oci-how-to/contribute-to-these-docs.rst
@@ -1,5 +1,5 @@
 Contribute to these docs
-========================
+************************
 
 .. include:: ../../reuse/contribute-to-docs.txt
    :start-after: Start: How to contribute
@@ -13,7 +13,7 @@ Contribute to these docs
 
 	PROJECT=oci make run
 
-Setting the `PROJECT` parameter to ``oci`` ensures that the documentation set for `Ubuntu on OCI Registries` gets built. This parameter is needed to distinguish between the different documentation sets present in the repository.
+Setting the `PROJECT` parameter to ``oci`` ensures that the documentation set for `Ubuntu on Container Registries` gets built. This parameter is needed to distinguish between the different documentation sets present in the repository.
 
 .. include:: ../../reuse/contribute-to-docs.txt
    :start-after: Start: How to contribute (continued)

--- a/oci/oci-how-to/create-chiselled-ubuntu-image.rst
+++ b/oci/oci-how-to/create-chiselled-ubuntu-image.rst
@@ -1,7 +1,7 @@
 Create a chiselled Ubuntu base image for C/C++, Go and Rust applications
-========================================================================
+************************************************************************
 
-This guide will provide step-by-step instructions on how  to create your own chiselled Ubuntu container image to run a compiled application.
+This guide will provide step-by-step instructions on how to create your own chiselled Ubuntu container image to run a compiled application.
 
 - Chiselled Ubuntu are appliance-type container images combining both the advantages of distroless and Ubuntu to create smaller, more secure containers, without loosing the value add of a stable Linux distribution.
 - The reduced size of the containers reduces the overall attack surface. Combined with the support and content quality from the Ubuntu distribution, chiselled Ubuntu is a significant security improvement.

--- a/oci/oci-how-to/create-chiselled-ubuntu-image.rst
+++ b/oci/oci-how-to/create-chiselled-ubuntu-image.rst
@@ -1,5 +1,5 @@
-Create a chiselled Ubuntu base image for C/C++, Go and Rust applications
-************************************************************************
+Create a chiselled Ubuntu image for C/C++, Go and Rust applications
+*******************************************************************
 
 This guide will provide step-by-step instructions on how to create your own chiselled Ubuntu container image to run a compiled application.
 
@@ -8,12 +8,12 @@ This guide will provide step-by-step instructions on how to create your own chis
 - Chisel provides a developer-friendly CLI to install slices of packages from the upstream Ubuntu distribution onto the container filesystem.
 
 
-Build the chiselled Ubuntu base image
--------------------------------------
+Build the chiselled Ubuntu image
+--------------------------------
 
 This image must contain all the essential slices that are required for the execution of common compiled applications. As a base, the must-have list of slices is:
 
-- **base-files_base** and **base-files_release-info**: will give you the overall base structure of the container image's filesystem, together with the underlying Ubuntu base's release information,
+- **base-files_base** and **base-files_release-info**: will give you the overall base structure of the container image's filesystem, together with the underlying Ubuntu release information,
 - **ca-certificates_data**: for cryptographic certificate verifications,
 - **libgcc-s1_libs** and **libc6_libs**: for the libgcc-s1 and libc6 libraries.
 
@@ -56,18 +56,18 @@ Start by creating a Dockerfile with the following content:
    FROM scratch
    COPY --from=builder /rootfs /
 
-Build the chiselled Ubuntu base image by running:
+Build the chiselled Ubuntu image by running:
 
 ..  code-block:: bash
    
-   docker build -t chiselled-ubuntu-base:latest . --build-arg ARCH=<your_arch> # example ARCH=amd64
+   docker build -t chiselled-ubuntu:latest . --build-arg ARCH=<your_arch> # example ARCH=amd64
 
 You'll then find yourself with a new container image with approximately 5MB (or 2.5MB when compressed). 
 
 Build the application image
 ---------------------------
 
-Now that you have the ``chiselled-ubuntu-base:latest`` image, you can simply add your compiled application to the image and run it from there. For the sake of simplicity, this guide will give your three very simple “Hello World” application examples for C, Go and Rust.
+Now that you have the ``chiselled-ubuntu:latest`` image, you can simply add your compiled application to the image and run it from there. For the sake of simplicity, this guide will give you three very simple “Hello World” application examples for C, Go and Rust.
 
 
 .. tabs::
@@ -118,11 +118,11 @@ Now that you have the ``chiselled-ubuntu-base:latest`` image, you can simply add
    
 
 
-To build the final application image, you simply need to add your compiled executable to the ``chiselled-ubuntu-base:latest`` container image. So your new Dockerfile should be similar to:
+To build the final application image, you simply need to add your compiled executable to the ``chiselled-ubuntu:latest`` container image. So your new Dockerfile should be similar to:
 
 .. code-block:: dockerfile
 
-   FROM chiselled-ubuntu-base:latest
+   FROM chiselled-ubuntu:latest
    COPY app /
    ENTRYPOINT [ "./app" ]
 

--- a/oci/oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster.rst
+++ b/oci/oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster.rst
@@ -1,5 +1,7 @@
+.. _how-to-deploy-pro-container-on-pro-cluster:
+
 Deploy Ubuntu Pro containers on Kubernetes
-==========================================
+******************************************
 
 You can easily deploy your Ubuntu Pro container images on Kubernetes clusters, provided
 that said clusters are composed of Ubuntu Pro nodes. Read more on the

--- a/oci/oci-how-to/enable-pro-services.rst
+++ b/oci/oci-how-to/enable-pro-services.rst
@@ -1,0 +1,3 @@
+.. _oci-how-to-enable-pro-services:
+
+.. include:: /_external/enable-pro-services.rst

--- a/oci/oci-how-to/getting-started.rst
+++ b/oci/oci-how-to/getting-started.rst
@@ -27,7 +27,7 @@ This is where to find the Ubuntu container images:
 	.. tab:: IronBank
 
          .. note::
-            Please note that these Ubuntu container images may have special terms of use and fall under Ubuntu Pro. Please reach out if you would like to use the Ubuntu container images from IronBank.
+            Please note that these Ubuntu container images may have special terms of use and fall under Ubuntu Pro. Please `reach out <rocks@canonical.com>`_ if you would like to use the Ubuntu container images from IronBank.
             
 
 

--- a/oci/oci-how-to/getting-started.rst
+++ b/oci/oci-how-to/getting-started.rst
@@ -1,0 +1,44 @@
+Getting Started
+***************
+
+This is where to find the Ubuntu container images:
+
+.. tabs::
+
+	.. tab:: Docker Hub
+
+         .. code-block:: bash
+
+            docker pull ubuntu:latest
+            
+
+	.. tab:: Amazon ECR
+
+         .. code-block:: bash
+            
+            docker pull public.ecr.aws/ubuntu/ubuntu:latest
+
+	.. tab:: Microsoft ACR
+
+         .. code-block:: bash
+            
+            docker pull ubuntu.azurecr.io/ubuntu:latest
+
+	.. tab:: IronBank
+
+         .. note::
+            Please note that these Ubuntu container images may have special terms of use and fall under Ubuntu Pro. Please reach out if you would like to use the Ubuntu container images from IronBank.
+            
+
+
+
+Refresh rate
+------------
+
+The Ubuntu base container images can be automatically updated multiple times a
+day, depending on whether there have been upstream changes in the Ubuntu archives
+affecting the packages that constitute the container image.
+
+**Exception**: the only exception is the official Ubuntu image in Docker Hub which,
+due to the Docker's policies, cannot be submitted too regularly, and thus are
+only updated every two weeks.

--- a/oci/oci-how-to/index.rst
+++ b/oci/oci-how-to/index.rst
@@ -24,7 +24,7 @@ Learn how to build your own Ubuntu Pro container image from a regular Ubuntu con
 .. toctree::
    :maxdepth: 1
 
-   enable-pro-services
+   Enable Ubuntu Pro services in a Dockerfile <enable-pro-services>
 
 
 Deployments
@@ -47,7 +47,7 @@ You can create even smaller Ubuntu container images with Chisel.
 .. toctree::
    :maxdepth: 1
 
-   create-chiselled-ubuntu-image
+   Create a chiselled Ubuntu image <create-chiselled-ubuntu-image>
 
 
 Documentation

--- a/oci/oci-how-to/index.rst
+++ b/oci/oci-how-to/index.rst
@@ -1,0 +1,63 @@
+.. _oci-how-to:
+
+How-to guides
+*************
+
+If you have a specific goal but are already familiar with the Ubuntu container
+images, our How-to guides have more in-depth detail than our tutorials, and dig
+a bit further into more advanced usages of the Ubuntu container images.
+
+They'll help you achieve an end result but may require you to understand and
+adapt the steps to fit your specific requirements.
+
+.. toctree::
+   :maxdepth: 1
+
+   getting-started
+
+
+Ubuntu Pro
+----------
+
+Learn how to build your own Ubuntu Pro container image from a regular Ubuntu container image.
+
+.. toctree::
+   :maxdepth: 1
+
+   enable-pro-services
+
+
+Deployments
+-----------
+
+Learn about different deployment scenarios for Ubuntu container images.
+
+.. toctree::
+   :maxdepth: 1
+
+   deploy-pro-container-on-pro-kubernetes-cluster
+
+
+
+Chiselled Ubuntu
+----------------
+
+You can create even smaller Ubuntu container images with Chisel.
+
+.. toctree::
+   :maxdepth: 1
+
+   create-chiselled-ubuntu-image
+
+
+Documentation
+-------------
+
+If you have found something missing in this documentation, or have useful
+information to add whether it is a tutorial, a guide, or something else, we
+compiled a couple of guides for you to facilitate your contribution.
+
+.. toctree::
+   :maxdepth: 1
+
+   contribute-to-these-docs

--- a/oci/oci-reference/index.rst
+++ b/oci/oci-reference/index.rst
@@ -3,7 +3,7 @@
 Reference
 *********
 
-This section of the documentation contains an in-depth description the Ubuntu
+Here you'll find an in-depth description of the Ubuntu
 image's OCI configuration.
 
 .. toctree::

--- a/oci/oci-reference/index.rst
+++ b/oci/oci-reference/index.rst
@@ -1,0 +1,12 @@
+.. _oci-reference:
+
+Reference
+*********
+
+This section of the documentation contains an in-depth description the Ubuntu
+image's OCI configuration.
+
+.. toctree::
+   :maxdepth: 1
+
+   oci-image-configuration

--- a/oci/oci-reference/oci-image-configuration.rst
+++ b/oci/oci-reference/oci-image-configuration.rst
@@ -1,0 +1,44 @@
+Ubuntu OCI image configuration
+******************************
+
+The definition of the Ubuntu container image follows the `OCI image format
+specification <https://github.com/opencontainers/image-spec/blob/main/spec.md>`_.
+
+Thus, as with any other container image, the Ubuntu image contains enough metadata
+such that one can inspect the image without actually running the container.
+
+Layers
+------
+
+As explained in :ref:`ubuntu-oci-container-images`, the Ubuntu container
+images are built from a minimal rootfs tarball that is tailored for container
+environments. For each Ubuntu release, you'll find a corresponding `release
+branch in Launchpad <https://code.launchpad.net/~cloud-images-release-managers/cloud-images/+oci/ubuntu-base/+git/ubuntu-base>`_
+(e.g. ``noble-24.04``) with the build recipe and a reference to the respective
+architecture-specific rootfs tarballs.
+
+Image index
+-----------
+
+The Ubuntu container image is published with a multi-architecture image index,
+meaning that there will be a container image digest that will internally
+resolve to multiple architecture-specific digests.
+
+In other words, when pulling any Ubuntu container image by its OCI tag
+(e.g. ``ubuntu:24.04``), your container runtime should automatically find and
+pull the right container image for your host's architecture.
+
+If however, you'd like to pin a specific Ubuntu container architecture, you can
+pull the Ubuntu container image by its architecture-specific digest
+(e.g. ``ubuntu@sha256:<arch-specific-digest>``).
+
+Image configuration
+-------------------
+
+The Ubuntu container images are built and published with the following
+configurations:
+
+- no default OCI entrypoint,
+- ``bash`` is the default OCI command,
+- OCI labels to identify the image name (i.e. ``ubuntu``) and its release.
+

--- a/oci/oci-reference/oci-image-configuration.rst
+++ b/oci/oci-reference/oci-image-configuration.rst
@@ -38,7 +38,7 @@ Image configuration
 The Ubuntu container images are built and published with the following
 configurations:
 
-- no default OCI entrypoint,
+- no default `OCI entrypoint <https://github.com/opencontainers/image-spec/blob/b30f6ed04f94cd13f95b103f3533612a53cb3062/config.md?plain=1#L157>`_,
 - ``bash`` is the default OCI command,
 - OCI labels to identify the image name (i.e. ``ubuntu``) and its release.
 

--- a/oci/oci-tutorials/fips-ubuntu-container.rst
+++ b/oci/oci-tutorials/fips-ubuntu-container.rst
@@ -1,0 +1,3 @@
+.. _how-to-fips-ubuntu-container:
+
+.. include:: /_external/create-fips-container-image.rst

--- a/oci/oci-tutorials/index.rst
+++ b/oci/oci-tutorials/index.rst
@@ -1,0 +1,15 @@
+.. _oci-tutorials:
+
+
+Tutorials
+*********
+
+If you want to learn the basics from experience, then our tutorials will help
+you acquire the necessary competencies from real-life examples with fully
+reproducible steps.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   fips-ubuntu-container

--- a/readme.rst
+++ b/readme.rst
@@ -83,7 +83,7 @@ Each project has its own contribution guide:
 * `Azure <https://canonical-azure.readthedocs-hosted.com/en/latest/azure-how-to/contribute-to-these-docs/>`_
 * `Google <https://canonical-gcp.readthedocs-hosted.com/en/latest/google-how-to/contribute-to-these-docs/>`_
 * `IBM <https://canonical-ibm.readthedocs-hosted.com/en/latest/ibm-how-to/contribute-to-these-docs/>`_
-* `OCI Container registries <https://canonical-oci.readthedocs-hosted.com/en/latest/oci-how-to/contribute-to-these-docs/>`_
+* `OCI container registries <https://canonical-oci.readthedocs-hosted.com/en/latest/oci-how-to/contribute-to-these-docs/>`_
 * `Oracle <https://canonical-oracle.readthedocs-hosted.com/en/latest/oracle-how-to/contribute-to-these-docs/>`_
 
 

--- a/readme.rst
+++ b/readme.rst
@@ -1,7 +1,7 @@
 Ubuntu cloud documentation
 ==========================
 
-Documentation for Ubuntu on public clouds. This documentation is composed of seven related documentation sets. The first one is for content related to public clouds in general and includes links to the remaining six. Five of the remaining six pertain to different cloud partners (AWS, Azure, IBM, Google cloud and Oracle cloud), while the last one is for OCI registries.
+Documentation for Ubuntu on public clouds. This documentation is composed of seven related documentation sets. The first one is for content related to public clouds in general and includes links to the remaining six. Five of the remaining six pertain to different cloud partners (AWS, Azure, IBM, Google cloud and Oracle cloud), while the last one is for container (OCI) registries.
 
 Each documentation set is currently published to a different location:
 
@@ -83,7 +83,7 @@ Each project has its own contribution guide:
 * `Azure <https://canonical-azure.readthedocs-hosted.com/en/latest/azure-how-to/contribute-to-these-docs/>`_
 * `Google <https://canonical-gcp.readthedocs-hosted.com/en/latest/google-how-to/contribute-to-these-docs/>`_
 * `IBM <https://canonical-ibm.readthedocs-hosted.com/en/latest/ibm-how-to/contribute-to-these-docs/>`_
-* `OCI <https://canonical-oci.readthedocs-hosted.com/en/latest/oci-how-to/contribute-to-these-docs/>`_
+* `OCI Container registries <https://canonical-oci.readthedocs-hosted.com/en/latest/oci-how-to/contribute-to-these-docs/>`_
 * `Oracle <https://canonical-oracle.readthedocs-hosted.com/en/latest/oracle-how-to/contribute-to-these-docs/>`_
 
 


### PR DESCRIPTION
This PR includes:
 - a refactoring of the Ubuntu OCI docs, including titles and navigation
 - enforcement of the diataxis framework to the docs
 - additional guides and tutorials, some reused from other docs, to complete the information 