### PR TITLE
fix: Point to internal-public mattermost channel.

### DIFF
--- a/all-clouds/conf.py
+++ b/all-clouds/conf.py
@@ -20,7 +20,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',

--- a/aws/conf.py
+++ b/aws/conf.py
@@ -28,7 +28,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',

--- a/azure/conf.py
+++ b/azure/conf.py
@@ -29,7 +29,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -88,7 +88,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',

--- a/google/conf.py
+++ b/google/conf.py
@@ -28,7 +28,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',

--- a/ibm/conf.py
+++ b/ibm/conf.py
@@ -28,7 +28,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',

--- a/oci/conf.py
+++ b/oci/conf.py
@@ -22,7 +22,7 @@ html_context = {
     "discourse": "https://discourse.ubuntu.com/c/public-cloud/",
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    "mattermost": "https://chat.canonical.com/canonical/channels/public-cloud-eng",
+    "mattermost": "https://chat.canonical.com/canonical/channels/public-cloud",
     # Change to the GitHub URL for your project
     "github_url": "https://github.com/canonical/ubuntu-cloud-docs",
     # Change to the branch for this version of the documentation

--- a/oracle/conf.py
+++ b/oracle/conf.py
@@ -23,7 +23,7 @@ html_context = {
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud-eng',
+    'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',


### PR DESCRIPTION
Although canonical-internal links are of debatable value for public-facing docs, it can still be useful for internal feedback.
This changes the link to the internal-public channel as the eng channel is invite-only.