### PR TITLE
[public images] Minor reorganisation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -249,3 +249,4 @@ virtio
 unmount
 SeaBIOS
 customisations
+MAAS

--- a/all-clouds/index.rst
+++ b/all-clouds/index.rst
@@ -10,9 +10,9 @@ Ubuntu on public cloud
 
 **Everyone from individual developers to large enterprises use these Ubuntu images** on the public cloud of their choice. Highly regulated industries from the government, medical and finance sectors, use specific security-certified versions of these images for their workloads.
 
----------
+-----------------------------------------------------------------
 
-Public Cloud Partners
+Public cloud partners
 ---------------------
 
 Canonical in collaboration with cloud partners such as Amazon, Google, IBM, Microsoft and Oracle, creates optimised Ubuntu images for each of those clouds. These images are available in the respective marketplaces, and work seamlessly across different platforms within each cloud. 
@@ -30,10 +30,25 @@ For further details, refer to the cloud-specific documentation:
    .. grid-item-card:: :doc:`Ubuntu on IBM <ibm:index>` 
    .. grid-item-card:: :doc:`Ubuntu on Oracle <oracle:index>`
 
+-----------------------------------------------------------------
+
+
+Other Ubuntu images
+-------------------
+
+Apart from the specific public clouds, Canonical also produces a variety of Ubuntu images for use in other platforms such as LXD, MAAS and OCI container registries.
+
+
+..  grid:: 1 1 2 2
+   :padding: 0
+
+   .. grid-item-card:: :doc:`Ubuntu on OCI container registries <oci:index>`   
+   .. grid-item-card:: :doc:`Ubuntu public images <public-images:index>` 
 
 
 
-------------------------------------------------------------------------------------------------
+
+-----------------------------------------------------------------
 
 
 

--- a/all-clouds/index.rst
+++ b/all-clouds/index.rst
@@ -42,8 +42,8 @@ Apart from the specific public clouds, Canonical also produces a variety of Ubun
 ..  grid:: 1 1 2 2
    :padding: 0
 
-   .. grid-item-card:: :doc:`Ubuntu on OCI container registries <oci:index>`   
-   .. grid-item-card:: :doc:`Ubuntu public images <public-images:index>` 
+   .. grid-item-card:: :doc:`Ubuntu on OCI container registries <oci:index>`
+   .. grid-item-card:: :doc:`Ubuntu Public Images <public-images:index>`
 
 
 

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -213,7 +213,8 @@ intersphinx_mapping = {
     'google': ('https://canonical-gcp.readthedocs-hosted.com/en/latest/', None),
     'ibm': ('https://canonical-ibm.readthedocs-hosted.com/en/latest/', None),
     'oracle': ('https://canonical-oracle.readthedocs-hosted.com/en/latest/', None),
-    'oci': ('https://canonical-oci.readthedocs-hosted.com/en/latest/', None)
+    'oci': ('https://canonical-oci.readthedocs-hosted.com/en/latest/', None),
+    'public-images': ('https://canonical-public-images.readthedocs-hosted.com/en/latest/', None)
 }
 
 # Add CSS files (located in .sphinx/_static/)

--- a/public-images/index.rst
+++ b/public-images/index.rst
@@ -1,7 +1,7 @@
 Ubuntu Public Images
 ====================
 
-**Canonical produce generic (generic kernel) cloud images, LXD images (rootfs tarballs) and KVM optimised cloud images (KVM kernel)**. These images are public (unlike other cloud-specific images) and are available on `cloud-images.ubuntu.com <http://cloud-images.ubuntu.com>`_.
+**Canonical produces generic (generic kernel) cloud images, LXD images (rootfs tarballs) and KVM optimised cloud images (KVM kernel)**. These images are public (unlike other cloud-specific images) and are available on `cloud-images.ubuntu.com <http://cloud-images.ubuntu.com>`_.
 
 .. include:: ../reuse/common-intro.txt
    :start-after: Start: Product need and user
@@ -13,16 +13,16 @@ Ubuntu Public Images
 In this documentation
 ---------------------
 
-..  grid:: 1 1 1 1
+..  grid:: 1 1 2 2
    :padding: 0
 
    ..  grid-item:: :doc:`How-to guides <public-images-how-to/index>`
 
-      **Step-by-step guides** covering key operations and common tasks
+      **Step-by-step guides** covering key operations related to Vagrant.
 
-   .. grid-item:: :doc:`Explanation <public-images-explanation/index>`
+   .. grid-item:: :doc:`Vagrant - An explanation <public-images-explanation/vagrant>`
 
-      **Discussion and clarification** of key topics.
+      **What are Vagrant boxes** and our support status for them.
 
 
 ----------
@@ -46,7 +46,8 @@ suggestions, fixes and constructive feedback.
    :maxdepth: 1
 
    public-images-how-to/index
-   public-images-explanation/index
+   Vagrant - An explanation<public-images-explanation/vagrant>
+   public-images-how-to/contribute-to-these-docs
 
 .. _Get support: https://ubuntu.com/cloud/public-cloud
 .. _`Discuss on IRC`: https://web.libera.chat/#ubuntu-cloud

--- a/public-images/public-images-explanation/index.rst
+++ b/public-images/public-images-explanation/index.rst
@@ -1,9 +1,0 @@
-Explanation
-===========
-
-Discussion and clarification of some key topics:
-
-.. toctree::
-   :maxdepth: 1
-
-   Vagrant<vagrant>

--- a/public-images/public-images-how-to/build-vagrant-with-bartender.rst
+++ b/public-images/public-images-how-to/build-vagrant-with-bartender.rst
@@ -3,7 +3,7 @@
 Build a Vagrant box with Bartender
 ==================================
 
-`Ubuntu Bartender <https://github.com/ubuntu-bartenders/ubuntu-old-fashioned/tree/master/scripts/ubuntu-bartender>`_ (Bartender) is a script based on `Ubuntu Old Fashioned <https://github.com/ubuntu-bartenders/ubuntu-old-fashioned/tree/master>`_ to let you build Ubuntu cloud images locally using `livecd-rootfs <https://launchpad.net/livecd-rootfs>`_.
+`Ubuntu Bartender <https://github.com/ubuntu-bartenders/ubuntu-old-fashioned/tree/master/scripts/ubuntu-bartender>`_ (Bartender) is a script based on `Ubuntu Old Fashioned <https://github.com/ubuntu-bartenders/ubuntu-old-fashioned/tree/master>`_ that lets you build Ubuntu cloud images locally using `livecd-rootfs <https://launchpad.net/livecd-rootfs>`_.
 
 Disclaimer
 ----------

--- a/public-images/public-images-how-to/index.rst
+++ b/public-images/public-images-how-to/index.rst
@@ -2,25 +2,14 @@
 
 How-to guides
 =============
-These guides provide instructions for performing different operations related to our public image offerings.
-
-Vagrant
--------
+These guides provide instructions for performing basic operations related to Vagrant.
 
 - :ref:`vagrant-bartender`
 - :ref:`run-a-vagrant-box`
-
-Contributing to the docs
-------------------------
-
-If you come across any problems with this documentation and you want to help with corrections, suggestions or new content, here's how you can do that:
-
-- :ref:`public-images-contribute`
 
 .. toctree::
    :maxdepth: 1
    :hidden:
 
    Build a Vagrant box with Bartender<build-vagrant-with-bartender>
-   Contribute to these docs<contribute-to-these-docs>
    Run a Vagrant box<run-a-vagrant-box>

--- a/public-images/public-images-how-to/run-a-vagrant-box.rst
+++ b/public-images/public-images-how-to/run-a-vagrant-box.rst
@@ -12,7 +12,7 @@ For upstream, use a call such as:
 
 .. code::
 
-   vagrant init ubuntu/focal64
+   vagrant init ubuntu/jammy64
 
 To bring up the image, use
 

--- a/public-images/public-images-how-to/run-a-vagrant-box.rst
+++ b/public-images/public-images-how-to/run-a-vagrant-box.rst
@@ -2,7 +2,25 @@
 
 Run a Vagrant box
 =====================
-The quickest way to get a vagrant environment up and running is ``vagrant init <BOX>``. For upstream, use a call such as ``vagrant init ubuntu/focal64``. To bring up the image, ``vagrant up``. This will create a VM, create an ssh key and associate it with the vagrant user, and mount the default synced directory (``./`` to ``/vagrant``). The image should boot relatively quickly, dependent on hardware. The default Vagrant timeout is five minutes, and if it's even close to that, something has gone wrong.
+The quickest way to get a vagrant environment up and running is to run:
+
+.. code::
+
+   vagrant init <BOX>
+
+For upstream, use a call such as:
+
+.. code::
+
+   vagrant init ubuntu/focal64
+
+To bring up the image, use
+
+.. code::
+
+   vagrant up
+
+This will create a VM, create an ssh key and associate it with the vagrant user, and mount the default synced directory (``./`` to ``/vagrant``). The image should boot relatively quickly, dependent on hardware. The default Vagrant timeout is five minutes, and if it's even close to that, something has gone wrong.
 
 Custom boxes
 ------------
@@ -40,7 +58,7 @@ Common errors
 -------------
 Below you can find some of the more common errors that occur when attempting to run your Vagrant box.
 
-Multiple Hypervisor Incompatibility
+Multiple hypervisor incompatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 KVM/QEMU, Multipass, and VirtualBox are all hypervisors that may be used during the course of building or running Vagrant boxes. You may run into issues if you attempt to use multiple hypervisors at the same time.
 
@@ -52,11 +70,11 @@ When you try and start Vagrant after building your box, you may get a variation 
 
    VirtualBox can't enable the AMD-V extension. Please disable the KVM kernel extension, recompile your kernel and reboot (VERR_SVM_IN_USE)
 
-First check that the QEMU VM isn’t running. If it is then shut it down by pressing ``C-a x``. If this doesn’t resolve the error, use a process manager like ``htop`` to search for and end any ``kvm`` processes.
+First check that the QEMU VM isn't running. If it is then shut it down by pressing ``C-a x``. If this doesn't resolve the error, use a process manager like ``htop`` to search for and end any ``kvm`` processes.
 
 VirtualBox (Vagrant) running
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you have VirtualBox (Vagrant) running and you try and launch a QEMU VM, you may encounter the a variation on the following error:
+If you have VirtualBox (Vagrant) running and you try and launch a QEMU VM, you may encounter a variation of the following error:
 
 .. terminal::
 


### PR DESCRIPTION
 1. Remove explanation section since currently it only has 1 topic
 2. Update the generic descriptions to specify Vagrant since currently that is the only image we are talking about
 3. Correct some minor typos
 4. Include pointers to public images and OCI registries in the main public cloud page