### PR TITLE
Update build-vagrant-with-bartender.rst with missing dash

### DIFF
--- a/public-images/public-images-how-to/build-vagrant-with-bartender.rst
+++ b/public-images/public-images-how-to/build-vagrant-with-bartender.rst
@@ -80,7 +80,7 @@ Extract the contents of the build tarball and ``cd`` to the location of the ``.b
 
 .. code:: bash
 
-   vagrant box add livecd.ubuntu-cpc.vagrant.box –name noble_bartender
+   vagrant box add livecd.ubuntu-cpc.vagrant.box -–name noble_bartender
    vagrant init noble_bartender
    vagrant up
    vagrant ssh


### PR DESCRIPTION
Should be a double dash for the `name` arg when adding a vagrant box.

`--name BOX                   Name of the box`