### PR TITLE
feat(aws): add marketplace identifiers for EKS 1.30

### DIFF
--- a/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -40,5 +40,9 @@ Ubuntu 20.04 LTS for EKS 1.29,amd64,``prod-lg73jq6vy35h2``,✓
 Ubuntu 20.04 LTS for EKS 1.29,arm64,``prod-htjgvopsb6wo2``,✓
 Ubuntu 22.04 LTS for EKS 1.29,amd64,``prod-lg73jq6vy35h2``,✓
 Ubuntu 22.04 LTS for EKS 1.29,arm64,``prod-htjgvopsb6wo2``,✓
+Ubuntu 22.04 LTS for EKS 1.30,amd64,``prod-ju4oliv6acvmu``,✓
+Ubuntu 22.04 LTS for EKS 1.30,arm64,``prod-ju4oliv6acvmu``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,amd64,``prod-zhspprfykjuvy``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,arm64,``prod-ixonrj2zphe7a``,✓
+Ubuntu Pro 22.04 LTS for EKS 1.30,amd64,``prod-osdss3jl4ihci``,✓
+Ubuntu Pro 22.04 LTS for EKS 1.30,arm64,``prod-osdss3jl4ihci``,✓


### PR DESCRIPTION
That includes EKS and EKS-Pro.