### PR TITLE
public-images: vagrant images always point to latest published image

### DIFF
--- a/public-images/public-images-explanation/vagrant.rst
+++ b/public-images/public-images-explanation/vagrant.rst
@@ -14,6 +14,8 @@ When are they published
 ~~~~~~~~~~~~~~~~~~~~~~~
 Boxes are published daily.
 
+Boxes published to Vagrant Cloud all point to the latest published version hosted on cloud-images.ubuntu.com, despite their publication date.
+
 How are they built
 ~~~~~~~~~~~~~~~~~~
 The VirtualBox Vagrant box is produced as part of a "Base" build with the code living in `livecd-roofs <https://git.launchpad.net/livecd-rootfs/tree/live-build/ubuntu-cpc/hooks.d/base/vagrant.binary>`_. The build generates a ``box.ovf`` config file, a config drive ``vmdk``, the base server ``vmdk``, Vagrantfile, and Vagrant metadata. These build components are then combined in the ``.box`` tarball.


### PR DESCRIPTION
Add a note about vagrant versions, as part of image cleanup.

Refs: [0] https://warthogs.atlassian.net/jira/software/c/projects/CPC/issues/CPC-953