### PR TITLE
Fix typo "Instantiate the image" on launch-ubuntu-ec2-instance.rst

### DIFF
--- a/aws/aws-how-to/instances/launch-ubuntu-ec2-instance.rst
+++ b/aws/aws-how-to/instances/launch-ubuntu-ec2-instance.rst
@@ -76,7 +76,7 @@ Security groups allow you to specify firewalling rules for your instances. To un
 
 .. _instantiate-image-on-ec2:
 
-Instantiate the image
+Launch the instance
 ---------------------
 
 Using the AMI ID and key pair obtained above, launch an instance by running:


### PR DESCRIPTION
Just a small typo/discrepancy I noticed while reading through AWS's `launch-ubuntu-ec2-instance.rst`.