### PR TITLE
fix(ec2): Remove mantic product ids

### DIFF
--- a/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -11,10 +11,6 @@ Ubuntu 22.10,amd64,``prod-663ryfcvanyqi``,✓
 Ubuntu 22.10,arm64,``prod-aizbragkux5k2``,✓
 Minimal Ubuntu 22.10,amd64,``prod-k62pbab6qb6ws``,✓
 Minimal Ubuntu 22.10,arm64,``prod-haniqpk5itina``,✓
-Ubuntu 23.10,amd64,``prod-tx7uupluohrfk``,✓
-Ubuntu 23.10,arm64,``prod-2ajtlwthyvpc6``,✓
-Minimal Ubuntu 23.10,amd64,``prod-segy4h4e5x5zq``,✓
-Minimal Ubuntu 23.10,arm64,``prod-xxfuncfabpasi``,✓
 Ubuntu 24.04,amd64,``prod-ib2w5aw4ynhey``,✓
 Ubuntu 24.04,arm64,``prod-uovi4c667gqya``,✓
 Minimal Ubuntu 24.04,amd64,``prod-u7oazfncxktmo``,✓


### PR DESCRIPTION
Mantic is EOL as of 2024-07-11.

Listings are depreacated and not available
to subscribe.