### PR TITLE
Bug fix for sphinx related build errors.

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -7,6 +7,7 @@
 GitPython
 canonical-sphinx-extensions
 furo
+git+https://github.com/k-dimple/sphinx-multiproject.git
 linkify-it-py
 myst-parser
 pyspelling
@@ -14,7 +15,6 @@ sphinx
 sphinx-autobuild
 sphinx-copybutton
 sphinx-design
-sphinx-multiproject
 sphinx-notfound-page
 sphinx-reredirects
 sphinx-tabs

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -201,7 +201,7 @@ custom_extensions = [
 # sphinx-notfound-page, sphinx-reredirects, sphinx-tabs, sphinxcontrib-jquery,
 # sphinxext-opengraph
 custom_required_modules = [
-    'sphinx-multiproject'
+    'git+https://github.com/k-dimple/sphinx-multiproject.git'
 ]
 
 # Disable Sphinx tab closing


### PR DESCRIPTION
**Sample error**:
```
copying images... [100%] all-clouds-how-to/check-cve-on-instance-images/0_oscap_oval_cve_scan_report.png Exception occurred:
  File "/xxx/ubuntu-cloud-docs/.sphinx/venv/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 780, in copy_image_files
    self.srcdir / src, err)
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

**Occurs when** sphinx-multiproject extension is used and images are included in .rst files

**Fix**: Latest version of Sphinx expects 'srcdir' to be a Path, but the multiproject extension updates and returns 'srcdir' as a str.

A personal (temporary) fork of the multiproject extension was created with the required change and that is now specified in the custom_config.py as the extension to be used (instead of sphinx-multiproject). This will be reverted once the upstream multiproject extension is corrected. 