### PR TITLE
Fix minor typo in how-to index page

### DIFF
--- a/oci/oci-how-to/index.rst
+++ b/oci/oci-how-to/index.rst
@@ -4,7 +4,7 @@ How-to guides
 *************
 
 If you have a specific goal but are already familiar with the Ubuntu container
-images, our how-to guides have more in-depth detail than our tutorials, and dig
+images, our how-to guides have more in-depth details than our tutorials, and dig
 a bit further into the more advanced uses of Ubuntu container images.
 
 They'll help you achieve an end result but may require you to understand and


### PR DESCRIPTION
Hi @k-dimple,

This is a really minor change mostly just to get myself acquainted with Canonical doc sets hosted in Git repos and published via RTD, and the process of editing them, as part of an onboarding exercise. Please help me review it whenever you can. I'd also appreciate any feedback/advice. Thank you.