### PR TITLE
feat(oracle): update oke support matrix for network-type

### DIFF
--- a/oracle/oracle-how-to/deploy-oke-nodes-using-ubuntu-images.rst
+++ b/oracle/oracle-how-to/deploy-oke-nodes-using-ubuntu-images.rst
@@ -34,7 +34,7 @@ The availability of networking plugins (Flannel / VCN Native) depends on the typ
      - Yes
    * - 
      - VCN Native
-     - Yes
+     - No
    * - Self-Managed
      - Flannel
      - Yes


### PR DESCRIPTION
There are ongoing efforts to get VCN native CNI working with OKE, so the public docs should reflect that.