### PR TITLE
feat(aws): add support options overview

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -44,6 +44,7 @@ cloudimg
 CloudSigma
 CNCF
 config
+CPC
 CPUs
 cron
 cryptographic
@@ -240,6 +241,7 @@ runtimes
 rustc
 rustup
 RSA
+SaaS
 scalability
 SDK
 SeaBIOS

--- a/aws/aws-reference/index.rst
+++ b/aws/aws-reference/index.rst
@@ -9,3 +9,5 @@ Technical information about some specific topics:
    Ubuntu on AWS Announcements <aws-announcements>
    EC2 credentials <ec2-credentials>
    EKS kubelet snap <eks-kubelet-snap>
+   Support options on AWS <support>
+   What does Ubuntu Pro provide <pro>

--- a/aws/aws-reference/pro.rst
+++ b/aws/aws-reference/pro.rst
@@ -1,0 +1,45 @@
+Ubuntu Pro on AWS
+-----------------
+`Ubuntu Pro`_ is a paid offering that 
+provides expanded security coverage, enhanced kernel patching, and 
+hardening options for compliance frameworks. All Ubuntu Pro images on 
+Amazon receive the following features through Pro.
+
+Expanded Security Maintenance (ESM)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`ESM`_ extends the security patching of
+the main archive to 10 years through the `esm-infra` entitlement. In addition
+to patching the core of Ubuntu (i.e. the `Ubuntu main` repository), Pro also offers security maintenance of the 
+`Ubuntu universe` repository. This security coverage is considered best effort
+without Ubuntu Pro.
+
+Livepatch
+~~~~~~~~~
+`Livepatch`_ applies security updates
+to the kernel for critical and high security vulnerabilities in a live system.
+This allows system administrators to minimise downtime between
+scheduled maintenance windows. This is particularly helpful for workloads
+that are expensive to migrate, such as kubernetes workers for EKS.
+
+Compliance
+~~~~~~~~~~
+Ubuntu Pro offers compliance options for users that need to apply 
+CIS (level 1 and 2) or FIPS hardening. FIPS is currently supported
+on Ubuntu 18.04 and 20.04. For 22.04, it is currently available through the
+`fips-preview` and `fips-updates` repositories provided through the 
+FIPS pro entitlement, but these modules are not yet certified.
+
+Ubuntu Landscape
+~~~~~~~~~~~~~~~~
+All Ubuntu Pro customers are entitled to the usage of 
+`Landscape <https://ubuntu.com/landscape>_` self-hosted and SaaS solutions.
+Landscape is an endpoint management solution for monitoring your Ubuntu
+estate. This includes alerting for security vulnerabilities, patching status,
+managing repository mirrors, and more. To sign up for Landscape SaaS see
+the `sign up page`_.
+
+.. _`Ubuntu Pro`: https://ubuntu.com/aws/pro
+.. _`ESM`: https://ubuntu.com/security/esm
+.. _`Livepatch`: https://ubuntu.com/security/livepatch
+.. _`Landscape`: https://ubuntu.com/landscape
+.. _`sign up page`: https://landscape.canonical.com/signup

--- a/aws/aws-reference/support.rst
+++ b/aws/aws-reference/support.rst
@@ -1,0 +1,42 @@
+Support options on AWS
+============================
+
+Ubuntu Pro on AWS
+-----------------
+Ubuntu Pro provides numerous support options. Please see the :doc:`Pro <pro>` page for 
+more details.
+
+
+Canonical support
+-----------------
+Purchasing Pro through the AWS provides a convenient mechanism for getting access to the above features
+using a unified billing portal. However, Ubuntu pro images published under the
+`Canonical Group Limited marketplace seller <https://aws.amazon.com/marketplace/search/results?searchTerms=ubuntu+pro&CREATOR=565feec9-3d43-413e-9760-c651546613f2&filters=CREATOR>`_
+account or launched through to the EC2 console does not include phone support. 
+If you would like to receive 24/5 or 24/7 phone support you can do so with the following options.
+
+* Private offers for marketplace listings
+* Ubuntu Pro tokens
+
+Ubuntu Pro tokens can not be purchased through unified billing, but it offers flexibility in where
+you deploy Pro. For instance, it can be used to provide Pro entitlements on on premise or hybrid
+cloud deployments.
+
+To purchase phone support please reach out to aws@canonical.com.
+
+
+Amazon front line support
+-------------------------
+Canonical and Amazon collaborate on publishing Ubuntu Pro images
+through the `Amazon Web Services marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=ubuntu+pro&CREATOR=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&filters=CREATOR>`_.
+Users of these images are able to get support directly through the
+`AWS support portal <https://console.aws.amazon.com/support/home#/case/create?issueType=technical>`_.
+
+
+Public Bug Tracker
+------------------
+The Canonical Public Cloud (CPC) team maintains a bug tracker for all cloud images. If you find
+a problem with a cloud image you case `file a bug <https://bugs.launchpad.net/cloud-images/+filebug>`_.
+When creating a bug please describe the issue, provide a minimal reproducer, and ensure you include
+which AMI you see this issue on. CPC regularly triage issues but note that support here is
+best effort.


### PR DESCRIPTION
This adds an overview for how to get support on AWS, including what Pro provides, AWS frontline support, and getting expanded support from Canonical