### PR TITLE
feat: add description on pro product availability

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -324,7 +324,7 @@ VPCs
 VSI
 vTPM
 workspaces
-Workspaces
+WorkSpaces
 xenial
 Xeon
 XZ

--- a/aws/aws-explanation/canonical-offerings.rst
+++ b/aws/aws-explanation/canonical-offerings.rst
@@ -76,10 +76,10 @@ The optimised ``linux-aws`` kernel used in most of the available offerings enabl
 Appliances and paid-for offerings
 ---------------------------------
 
-Ubuntu workspaces
+Ubuntu WorkSpaces
 ~~~~~~~~~~~~~~~~~
 
-`Ubuntu Workspaces`_ are virtual Ubuntu desktops powered by AWS. Workspaces is a paid offering supported through `Amazon Workspaces`_ and the image provided for workspaces is basically an Ubuntu Desktop running on EC2, with Ubuntu Pro services (ESM, livepatch) enabled by default.
+`Ubuntu WorkSpaces`_ are virtual Ubuntu desktops powered by AWS. WorkSpaces is a paid offering supported through `Amazon Workspaces`_ and the image provided for workspaces is basically an Ubuntu Desktop running on EC2, with Ubuntu Pro services (ESM, livepatch) enabled by default.
 
 Anbox cloud appliance
 ~~~~~~~~~~~~~~~~~~~~~
@@ -110,8 +110,8 @@ Charmed Kubeflow on AWS
 .. _`Elastic Fabric Adapter`: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html
 .. _`Nitro enclaves driver`: https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html
 .. _`AWS Graviton`: https://docs.aws.amazon.com/whitepapers/latest/aws-graviton-performance-testing/what-is-aws-graviton.html
-.. _`Ubuntu Workspaces`: https://ubuntu.com/aws/workspaces
-.. _`Amazon Workspaces`: https://aws.amazon.com/workspaces-family/
+.. _`Ubuntu WorkSpaces`: https://ubuntu.com/aws/workspaces
+.. _`Amazon WorkSpaces`: https://aws.amazon.com/workspaces-family/
 .. _`Anbox cloud`: https://anbox-cloud.io/ 
 .. _`AWS marketplace (Anbox cloud)`: https://aws.amazon.com/marketplace/search/results?searchTerms=Anbox&CREATOR=565feec9-3d43-413e-9760-c651546613f2&filters=CREATOR
 .. _`MicroK8s`: https://microk8s.io/

--- a/aws/aws-reference/pro.rst
+++ b/aws/aws-reference/pro.rst
@@ -5,6 +5,20 @@ provides expanded security coverage, enhanced kernel patching, and
 hardening options for compliance frameworks. All Ubuntu Pro images on 
 Amazon receive the following features through Pro.
 
+Pro product availability on AWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Pro is available for the following products.
+
+* Base server products
+* EKS worker images 
+* `Amazon WorkSpaces`_
+
+For launching server and EKS pro products, refer to 
+:doc:`../aws-how-to/instances/launch-ubuntu-ec2-instance`
+
+Feature overview
+================
+
 Expanded Security Maintenance (ESM)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `ESM`_ extends the security patching of
@@ -43,3 +57,4 @@ the `sign up page`_.
 .. _`Livepatch`: https://ubuntu.com/security/livepatch
 .. _`Landscape`: https://ubuntu.com/landscape
 .. _`sign up page`: https://landscape.canonical.com/signup
+.. _`Amazon WorkSpaces`: https://ubuntu.com/aws/workspaces


### PR DESCRIPTION
This adds a quick blurb on where Ubuntu Pro is on AWS.