### PR TITLE
feat(oke): VCN Native is now available for OKE

### DIFF
--- a/oracle/oracle-how-to/deploy-oke-nodes-using-ubuntu-images.rst
+++ b/oracle/oracle-how-to/deploy-oke-nodes-using-ubuntu-images.rst
@@ -34,7 +34,7 @@ The availability of networking plugins (Flannel / VCN Native) depends on the typ
      - Yes
    * - 
      - VCN Native
-     - No
+     - Yes
    * - Self-Managed
      - Flannel
      - Yes


### PR DESCRIPTION
VCN Native networking type is now available for OKE after squashing a long-term bug regarding udev and the kernel. The following changes reflect our support for all networking types offered by Oracle.