### PR TITLE
fix: remove focal EKS 1.29 marketplace entry

### DIFF
--- a/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -30,8 +30,6 @@ Ubuntu 20.04 LTS for EKS 1.27,amd64,``prod-ldmift6l2jtbk``,✓
 Ubuntu 20.04 LTS for EKS 1.27,arm64,``prod-rmbj4hjbxq3s4``,✓
 Ubuntu 20.04 LTS for EKS 1.28,amd64,``prod-liwkeak7e3q7e``,✓
 Ubuntu 20.04 LTS for EKS 1.28,arm64,``prod-lnp3hmtlqxkes``,✓
-Ubuntu 20.04 LTS for EKS 1.29,amd64,``prod-lg73jq6vy35h2``,✓
-Ubuntu 20.04 LTS for EKS 1.29,arm64,``prod-htjgvopsb6wo2``,✓
 Ubuntu 22.04 LTS for EKS 1.29,amd64,``prod-lg73jq6vy35h2``,✓
 Ubuntu 22.04 LTS for EKS 1.29,arm64,``prod-htjgvopsb6wo2``,✓
 Ubuntu 22.04 LTS for EKS 1.30,amd64,``prod-ju4oliv6acvmu``,✓


### PR DESCRIPTION
the current entry points to the jammy EKS 1.29 listings. a marketplace entry does not currently exist for focal EKS 1.29.

Fixes #307