### PR TITLE
Update create-different-instance-types.rst to encourage noble 24.04

### DIFF
--- a/google/google-how-to/gce/create-different-instance-types.rst
+++ b/google/google-how-to/gce/create-different-instance-types.rst
@@ -11,7 +11,7 @@ Create an Ubuntu LTS instance
 
 On your Google Cloud console, while creating a new instance from :guilabel:`Compute Engine` > :guilabel:`VM instances`> :guilabel:`CREATE INSTANCE`:
 
-* select ``Ubuntu`` and ``Ubuntu 22.04 LTS`` in :guilabel:`Boot disk` > :guilabel:`CHANGE` > :guilabel:`Operating system` and :guilabel:`Version`
+* select ``Ubuntu`` and ``Ubuntu 24.04 LTS`` in :guilabel:`Boot disk` > :guilabel:`CHANGE` > :guilabel:`Operating system` and :guilabel:`Version`
 
 
 .. _create-pro-on-gcp:
@@ -21,7 +21,7 @@ Create an Ubuntu Pro instance
 
 On your Google Cloud console, while creating a new instance from :guilabel:`Compute Engine` > :guilabel:`VM instances`> :guilabel:`CREATE INSTANCE`:
 
-* select ``Ubuntu Pro`` and ``Ubuntu 22.04 LTS Pro Server`` in :guilabel:`Boot disk` > :guilabel:`CHANGE` > :guilabel:`Operating system` and :guilabel:`Version`
+* select ``Ubuntu Pro`` and ``Ubuntu 24.04 LTS Pro Server`` in :guilabel:`Boot disk` > :guilabel:`CHANGE` > :guilabel:`Operating system` and :guilabel:`Version`
 
 Once the instance is up, ssh into it and run
 
@@ -64,7 +64,7 @@ Create an ARM-based instance
 On your Google Cloud console, while creating a new instance from :guilabel:`Compute Engine` > :guilabel:`VM instances`> :guilabel:`CREATE INSTANCE`:
 
 * choose the ARM CPU platform ``T2A`` in :guilabel:`Machine configuration` > :guilabel:`Series`
-* choose an ARM compatible OS and version, say ``Ubuntu`` and ``Ubuntu 22.04 LTS Minimal`` in :guilabel:`Boot disk` > :guilabel:`CHANGE` > :guilabel:`Operating system` and :guilabel:`Version` 
+* choose an ARM compatible OS and version, say ``Ubuntu`` and ``Ubuntu 24.04 LTS Minimal`` in :guilabel:`Boot disk` > :guilabel:`CHANGE` > :guilabel:`Operating system` and :guilabel:`Version` 
 
 
 .. _create-amd-sev-conf-compute-on-gcp:


### PR DESCRIPTION
The doc previously gave steps to launch a jammy 22.04 instance, but we should encourage people to be up to date on LTSes