### PR TITLE
fix: Add identifiers for 24.04 EKS 1.31 listings

### DIFF
--- a/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -36,9 +36,13 @@ Ubuntu 22.04 LTS for EKS 1.30,amd64,``prod-ju4oliv6acvmu``,✓
 Ubuntu 22.04 LTS for EKS 1.30,arm64,``prod-ju4oliv6acvmu``,✓
 Ubuntu 22.04 LTS for EKS 1.31,amd64,``prod-6cgarsgfcf6pw``,✓
 Ubuntu 22.04 LTS for EKS 1.31,arm64,``prod-37lry2b6efnve``,✓
+Ubuntu 24.04 LTS for EKS 1.31,amd64,``prod-jjmfgr4fqi24i``,✓
+Ubuntu 24.04 LTS for EKS 1.31,arm64,``prod-vu4rwlmwizmb2``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,amd64,``prod-zhspprfykjuvy``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,arm64,``prod-ixonrj2zphe7a``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.30,amd64,``prod-osdss3jl4ihci``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.30,arm64,``prod-osdss3jl4ihci``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.31,amd64,``prod-mtxapxlqfrxhk``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.31,arm64,``prod-v64fpuhgxrpgm``,✓
+Ubuntu Pro 24.04 LTS for EKS 1.31,amd64,``prod-7o5ls37u7nr4k``,✓
+Ubuntu Pro 24.04 LTS for EKS 1.31,arm64,``prod-mpcgirphmso2q``,✓


### PR DESCRIPTION
24.04 EKS 1.31 listings are now available.

Update csv file with identifiers.