### PR TITLE
feat: add matrix channel to all clouds footers

### DIFF
--- a/all-clouds/conf.py
+++ b/all-clouds/conf.py
@@ -22,6 +22,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 

--- a/aws/conf.py
+++ b/aws/conf.py
@@ -30,6 +30,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 

--- a/azure/conf.py
+++ b/azure/conf.py
@@ -31,6 +31,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 

--- a/google/conf.py
+++ b/google/conf.py
@@ -30,6 +30,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 

--- a/ibm/conf.py
+++ b/ibm/conf.py
@@ -30,6 +30,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 

--- a/oci/conf.py
+++ b/oci/conf.py
@@ -23,6 +23,9 @@ html_context = {
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)
     "mattermost": "https://chat.canonical.com/canonical/channels/public-cloud",
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
     # Change to the GitHub URL for your project
     "github_url": "https://github.com/canonical/ubuntu-cloud-docs",
     # Change to the branch for this version of the documentation

--- a/oracle/conf.py
+++ b/oracle/conf.py
@@ -25,6 +25,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 

--- a/public-images/conf.py
+++ b/public-images/conf.py
@@ -30,6 +30,10 @@ html_context = {
     # (use an empty value if you don't want to link)
     'mattermost': 'https://chat.canonical.com/canonical/channels/public-cloud',
 
+    # Change to the Matrix channel you want to link to
+    # (use an empty value if you don't want to link)
+    'matrix': 'https://matrix.to/#/#ubuntu-cloud:ubuntu.com',
+
     # Change to the GitHub URL for your project
     'github_url': 'https://github.com/canonical/ubuntu-cloud-docs',
 


### PR DESCRIPTION
As things move to matrix, document the new channel as a way to reach for community support.