### PR TITLE
feat: self-managed EKS ubuntu node groups

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -287,6 +287,7 @@ tunings
 tzdata
 UA
 ubuntu
+UbuntuPro
 udev
 UEFI
 uncompress

--- a/aws/aws-how-to/kubernetes/deploy-self-managed-node-group.rst
+++ b/aws/aws-how-to/kubernetes/deploy-self-managed-node-group.rst
@@ -1,0 +1,24 @@
+Deploy self-managed Ubuntu nodes
+================================
+
+Amazon provides a good baseline for `launch self-managed node groups`_. 
+Minor modifications to eksctl can enable the same functionality for Ubuntu nodes.
+
+To specify Ubuntu nodes, in the ``eksctl create nodegroup`` command, supply the `--node-ami-family argument` with one of
+the following supported Node AMI families:
+
+* Ubuntu2004
+* Ubuntu2204
+* UbuntuPro2204
+* Ubuntu2404
+* UbuntuPro2404
+
+The `--node-ami` flag can be used to specify a specific AMI. By default, this
+uses SSM parameters to select the latest available version for the given Node AMI
+family. To look up the AMI ID for the region you wish to deploy to please reference
+the :doc:`find ubuntu images <../instances/find-ubuntu-images>` page. 
+
+
+
+.. _`launch self-managed node groups`: https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+.. _`find ubuntu images`: "../instances/find-ubuntu-images.rst"

--- a/aws/aws-how-to/kubernetes/index.rst
+++ b/aws/aws-how-to/kubernetes/index.rst
@@ -26,4 +26,5 @@ Using EKS
    Deploy an Ubuntu Pro cluster <deploy-ubuntu-pro-cluster-with-eks-pro-ami>
    Deploy an Ubuntu Pro FIPS cluster <deploy-ubuntu-pro-fips-cluster>
    Deploy an Ubuntu Pro cluster using tokens <deploy-ubuntu-pro-cluster>
+   Deploy a self-managed Ubuntu node group <deploy-self-managed-node-group>
    Enable GPUs on EKS <enable-gpus-on-eks>


### PR DESCRIPTION
This adds a small set of documentation to reference the upstream self-managed node group docs and specifying how to use eksctl to launch the node groups.