### PR TITLE
feat(aws): add EKS-Pro Focal listings

### DIFF
--- a/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -40,6 +40,12 @@ Ubuntu 24.04 LTS for EKS 1.31,amd64,``prod-jjmfgr4fqi24i``,✓
 Ubuntu 24.04 LTS for EKS 1.31,arm64,``prod-vu4rwlmwizmb2``,✓
 Ubuntu 24.04 LTS for EKS 1.32,amd64,``prod-apo236yrqs4ve``,✓
 Ubuntu 24.04 LTS for EKS 1.32,arm64,``prod-vboehvlnbsy3e``,✓
+Ubuntu Pro 20.04 LTS for EKS 1.27,amd64,``prod-hevrtde27mszy``,✓
+Ubuntu Pro 20.04 LTS for EKS 1.27,arm64,``prod-pwq543dpfrkro``,✓
+Ubuntu Pro 20.04 LTS for EKS 1.28,amd64,``prod-hqauo4m24unwa``,✓
+Ubuntu Pro 20.04 LTS for EKS 1.28,arm64,``prod-tlw6qfb47lam2``,✓
+Ubuntu Pro 20.04 LTS for EKS 1.29,amd64,``prod-4yrqysyuk6vts``,✓
+Ubuntu Pro 20.04 LTS for EKS 1.29,arm64,``prod-mu642qufmvg5i``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,amd64,``prod-zhspprfykjuvy``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,arm64,``prod-ixonrj2zphe7a``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.30,amd64,``prod-osdss3jl4ihci``,✓


### PR DESCRIPTION
Focal is EOL soon so add the Pro based Focal EKS identifiers for the AWS Marketplace listings.