### PR TITLE
Update run-an-ova-using-virtualbox.rst

### DIFF
--- a/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
+++ b/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
@@ -108,6 +108,7 @@ ISO seed image.
 1. Create a YAML file with password authorization enabled:
 
 Choose between two YAML configurations based on your cloud-init version
+
 .. tabs::
 
   .. group-tab:: cloud-init >= 22.3
@@ -137,30 +138,6 @@ Choose between two YAML configurations based on your cloud-init version
       ssh_pwauth: True
       ssh_authorized_keys: <YOUR_PUB_KEY>
       EOF
-
-.. code:: bash
-
-  cat <<EOF > my-cloud-config.yaml
-  #cloud-config
-  chpasswd:
-    list: |
-      ubuntu:ubuntu
-    expire: False
-  ssh_pwauth: True
-  ssh_authorized_keys: <YOUR_PUB_KEY>
-  EOF
-
-.. code:: bash
-
-  cat <<EOF > my-cloud-config.yaml
-  #cloud-config
-  chpasswd:
-    users:
-    - {name: ubuntu, password: ubuntu, type: text}
-    expire: False
-  ssh_pwauth: True
-  ssh_authorized_keys: <YOUR_PUB_KEY>
-  EOF
 
 Replace ``<YOUR_PUB_KEY>`` with your public key.
 

--- a/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
+++ b/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
@@ -112,9 +112,9 @@ ISO seed image.
   cat <<EOF > my-cloud-config.yaml
   #cloud-config
   chpasswd:
-    list: |
-      ubuntu:ubuntu
-  expire: False
+    users:
+    - {name: ubuntu, password: ubuntu, type: text}
+    expire: False
   ssh_pwauth: True
   ssh_authorized_keys: <YOUR_PUB_KEY>
   EOF

--- a/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
+++ b/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
@@ -107,7 +107,7 @@ ISO seed image.
 
 1. Create a YAML file with password authorization enabled:
 
-Choose between two YAML configurations based on your cloud-init version
+Choose between two YAML configurations based on your cloud-init version:
 
 .. tabs::
 

--- a/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
+++ b/public-images/public-images-how-to/run-an-ova-using-virtualbox.rst
@@ -108,7 +108,35 @@ ISO seed image.
 1. Create a YAML file with password authorization enabled:
 
 Choose between two YAML configurations based on your cloud-init version
-(use the first for versions prior to 22.3 and the second for 22.3 and above).
+.. tabs::
+
+  .. group-tab:: cloud-init >= 22.3
+
+    .. code:: bash
+
+      cat <<EOF > my-cloud-config.yaml
+      #cloud-config
+      chpasswd:
+        users:
+        - {name: ubuntu, password: ubuntu, type: text}
+        expire: False
+      ssh_pwauth: True
+      ssh_authorized_keys: <YOUR_PUB_KEY>
+      EOF
+      
+  .. group-tab:: cloud-init < 22.3
+
+    .. code:: bash
+
+      cat <<EOF > my-cloud-config.yaml
+      #cloud-config
+      chpasswd:
+        list: |
+          ubuntu:ubuntu
+        expire: False
+      ssh_pwauth: True
+      ssh_authorized_keys: <YOUR_PUB_KEY>
+      EOF
 
 .. code:: bash
 


### PR DESCRIPTION
Minor fixes in chpasswd example:
- set 'users' array instead of 'list' due to 'list' being [deprecated in version 22.2](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#set-passwords)
- 'expire' is a chpasswd key, so it should be indented

How I validated scheme
```
$ cat heck.yaml
#cloud-config
chpasswd:
  users:
  - {name: ubuntu, password: ubuntu, type: text}
  expire: False
ssh_pwauth: True

$ sudo cloud-init schema -c heck.yaml --annotate
Valid schema heck.yaml
```