### PR TITLE
feat(azure): Add Specialized Hardware images to find-images how-to

### DIFF
--- a/azure/azure-how-to/instances/find-ubuntu-images.rst
+++ b/azure/azure-how-to/instances/find-ubuntu-images.rst
@@ -386,7 +386,7 @@ Quick start: `Ubuntu Pro CIS 20.04 LTS on Azure  <https://portal.azure.com/#crea
 Specialized-hardware-compatible offers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These images are optimized for use in `virtual machines running on NVIDIA GB200 hardware <https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series>`.
+These images are optimized for use in `virtual machines running on NVIDIA GB200 hardware <https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series>`_.
 
 Ubuntu 24.04 LTS (GB200-Compatible) - Noble Numbat
 ++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/azure/azure-how-to/instances/find-ubuntu-images.rst
+++ b/azure/azure-how-to/instances/find-ubuntu-images.rst
@@ -383,6 +383,44 @@ Quick start: `Ubuntu Pro CIS 20.04 LTS on Azure  <https://portal.azure.com/#crea
      - ``Canonical:0001-com-ubuntu-pro-minimal-cis-focal:pro-cis-minimal-20_04-gen2:latest``
 
 
+Specialized-hardware-compatible offers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These images are optimized for use in `virtual machines running on NVIDIA GB200 hardware <https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nd-gb200-v6-series>`.
+
+Ubuntu 24.04 LTS (GB200-Compatible) - Noble Numbat
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Quick start: `Ubuntu 24.04 LTS (GB200-Compatible) on Azure <https://portal.azure.com/#create/canonical.ubuntu-24_04-ltsspecialized-hardware>`_
+
+.. list-table::
+   :widths: 10 9 50
+   :header-rows: 1
+
+   * - **Architecture**
+     - **Hyper-V Generation**
+     - **URN**
+   * - Arm64
+     - Gen2
+     - ``Canonical:ubuntu-24_04-lts:specialized-hardware:latest``
+
+Ubuntu Pro 24.04 LTS (GB200-Compatible) - Noble Numbat
+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Quick start: `Ubuntu Pro 24.04 LTS (GB200-Compatible) on Azure <https://portal.azure.com/#create/canonical.ubuntu-24_04-ltsubuntu-pro-specialized-hardware>`_
+
+.. list-table::
+   :widths: 10 9 50
+   :header-rows: 1
+
+   * - **Architecture**
+     - **Hyper-V Generation**
+     - **URN**
+   * - Arm64
+     - Gen2
+     - ``Canonical:ubuntu-24_04-lts:ubuntu-pro-specialized-hardware:latest``
+
+
 List all images published by Canonical
 --------------------------------------
 


### PR DESCRIPTION
This commit adds the new Specialized Hardware free and Pro image lines to the Azure find-images how-to.

Refs: https://warthogs.atlassian.net/browse/CPC-6438

@k-dimple Please do not merge this pull request until the first images have been published to the Marketplace. I will let you know when we have reached that point (likely by Monday morning).