### PR TITLE
feat(oracle): Updated the docs to include our new OKE offerings

### DIFF
--- a/oracle/index.rst
+++ b/oracle/index.rst
@@ -30,6 +30,10 @@ In this documentation
 
        **Discussion and clarification** of key topics, such as our offerings on Oracle Cloud and an overview of available security features. 
 
+   ..  grid-item:: :doc:`Reference <oracle-reference/index>`
+
+      **References** of Ubuntu's offering on Oracle Cloud, such as a list of our available OKE images.
+
 
 ----------
 
@@ -51,6 +55,7 @@ community projects, contributions, suggestions, fixes and constructive feedback.
 
    oracle-how-to/index
    oracle-explanation/index
+   oracle-reference/index
 
 .. _Ubuntu release cycle: https://ubuntu.com/about/release-cycle
 .. _Get support: https://ubuntu.com/cloud/public-cloud

--- a/oracle/oracle-how-to/deploy-oke-nodes-using-ubuntu-images.rst
+++ b/oracle/oracle-how-to/deploy-oke-nodes-using-ubuntu-images.rst
@@ -1,47 +1,9 @@
 Deploy OKE nodes using Ubuntu images
 ====================================
 
-Ubuntu images are available for worker nodes on Oracle Kubernetes Engine (OKE) in Oracle Cloud. Currently there are only a select number of suites and Kubernetes versions supported due to this being a Limited Availability release. 
+Ubuntu images are available for worker nodes on Oracle Kubernetes Engine (OKE) in Oracle Cloud. Currently there are only a select number of suites and Kubernetes versions supported due to this being a Limited Availability release. For a list of supported OKE configurations, see our :doc:`Ubuntu availability on OKE </oracle-reference/ubuntu-availability-on-oke>` page.
 
 For node stability, the ``unattended-upgrades`` package has been removed from the Ubuntu image for OKE. Should your nodes need updates or security patches then refer to the Oracle documentation on `node cycling for managed nodes`_ and `node cycling for self-managed nodes`_.
-
-Available releases
-------------------
-
-.. list-table::
-   :header-rows: 1
-
-   * - Ubuntu Release
-     - OKE Version
-     - Location
-   * - 22.04 (Jammy Jellyfish)
-     - 1.29
-     - `List of Images <https://intcanonical.objectstorage.us-phoenix-1.oci.customer-oci.com/p/vpqQtYASl8IooEZ_sxfKDnzUkF1b-3lQmXPC_rXf4zARQYoW7ncE8BGGxNqdUuGa/n/intcanonical/b/oke-shared/o/>`_
-
-Networking plugin availability
-------------------------------
-
-The availability of networking plugins (Flannel / VCN Native) depends on the type of OKE node being used:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Node Type
-     - Plugin
-     - Supported
-   * - Managed
-     - Flannel
-     - Yes
-   * - 
-     - VCN Native
-     - Yes
-   * - Self-Managed
-     - Flannel
-     - Yes
-   * - 
-     - VCN Native
-     - Yes
-
 
 Prerequisites
 -------------

--- a/oracle/oracle-reference/index.rst
+++ b/oracle/oracle-reference/index.rst
@@ -1,0 +1,12 @@
+Reference
+=========
+
+This section contains reference material for Ubuntu on Oracle Cloud.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   Ubuntu Availability on OKE <ubuntu-availability-on-oke>
+
+

--- a/oracle/oracle-reference/ubuntu-availability-on-oke.rst
+++ b/oracle/oracle-reference/ubuntu-availability-on-oke.rst
@@ -1,0 +1,58 @@
+Ubuntu Availability on OKE
+==========================
+
+
+Available releases
+------------------
+
+The following Ubuntu images are available for worker nodes on Oracle Kubernetes Engine (OKE) in Oracle Cloud.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Ubuntu Release
+     - OKE Version
+     - End of Life
+     - Location
+   * - 22.04 (Jammy Jellyfish)
+     - 1.31.1
+     - 30 days after 1.34.1 OKE Release
+     - `List of Images <https://objectstorage.us-phoenix-1.oraclecloud.com/p/lH_ztqUFhNMHzlMqe6CLUlM1TrAI4OzTjq1adtUD8pP6sIQ-iVOfBq7juf9iGVA8/n/intcanonical/b/oke-shared/o/>`__
+   * -
+     - 1.32.1
+     - 30 days after 1.35.1 OKE Release
+     - `List of Images <https://objectstorage.us-phoenix-1.oraclecloud.com/p/YfyIxRjIiLNUMd8sT70NOKODXeCXwoNv3EHLJF2uz5NH6uDP7p0S_DnT_a4i4BqX/n/intcanonical/b/oke-shared/o/>`__
+   * - 24.04 (Noble Numbat)
+     - 1.31.1
+     - 30 days after 1.34.1 OKE Release
+     - `List of Images <https://objectstorage.us-phoenix-1.oraclecloud.com/p/hloW9HxqKIwuanrFdPSTFpgEjNbdijtApD_GbwSXuIKg18J2G866NmPgTRa78M8v/n/intcanonical/b/oke-shared/o/>`__
+   * -
+     - 1.32.1
+     - 30 days after 1.35.1 OKE Release
+     - `List of Images <https://objectstorage.us-phoenix-1.oraclecloud.com/p/xIj-IH-CNygD9rGfB-oYTcJCu3ouGF5EVblFTKea9_x31eljhQN9akosZ6E49suY/n/intcanonical/b/oke-shared/o/>`__
+
+
+Networking plugin availability
+------------------------------
+
+The availability of networking plugins (Flannel / VCN Native) depends on the type of OKE node being used:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Node Type
+     - Plugin
+     - Supported
+   * - Managed
+     - Flannel
+     - Yes
+   * -
+     - VCN Native
+     - Yes
+   * - Self-Managed
+     - Flannel
+     - Yes
+   * -
+     - VCN Native
+     - Yes
+


### PR DESCRIPTION
 - Split out a reference table from the `deploy-oke-nodes-using-ubuntu-images.rst` how-to page into a dedicated reference page.
 - Added our newly supported OKE 1.31.1 and 1.32.1 offerings into the newly added reference page.

These changes addresses CPC-7494 [0].

Refs:
 - [0] https://warthogs.atlassian.net/browse/CPC-7494