### PR TITLE
Increase linkcheck timeout to avoid a CI error

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -161,8 +161,7 @@ redirects = {
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
     'http://localhost:8000',
-    r'.*#.*',
-    'https://www.amd.com/content/dam/amd/en/documents/epyc-business-docs/white-papers/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf'
+    r'.*#.*'
     ]
 
 linkcheck_timeout = 300


### PR DESCRIPTION
The link points to a pdf that opens fine locally.