### PR TITLE
Remove Ubuntu version from AKS worker nodes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,6 @@ build:
       - PROJECT=google make spelling
       - PROJECT=ibm make spelling
       - PROJECT=oracle make spelling
-      - PROJECT=oci make spelling
       - PROJECT=public-images make spelling
 
 # Build documentation in the docs/ directory with Sphinx

--- a/azure/azure-explanation/ubuntu-on-aks-worker-nodes.rst
+++ b/azure/azure-explanation/ubuntu-on-aks-worker-nodes.rst
@@ -4,7 +4,7 @@ Ubuntu on AKS worker nodes
 Overview
 --------
 
-Ubuntu 22.04 LTS is the default operating system for worker nodes in the Azure Kubernetes Service (AKS). It is used in both system node pools and user node pools. The Ubuntu images are provided by Canonical and customized by Microsoft to ensure enhanced compatibility within the AKS environment. Specific methods are available to ensure timely security updates for these images.
+Ubuntu is the default operating system for worker nodes in the Azure Kubernetes Service (AKS). It is used in both system node pools and user node pools. The Ubuntu images are provided by Canonical and customized by Microsoft to ensure enhanced compatibility within the AKS environment. Specific methods are available to ensure timely security updates for these images.
 
 
 Image customization


### PR DESCRIPTION
The exact version that AKS uses is not clear from their [documentation](https://learn.microsoft.com/en-gb/azure/aks/node-images). So it is safer to just say Ubuntu like they do!