### PR TITLE
feat(gce): Update Pro upgrade instructions

### DIFF
--- a/google/google-how-to/gce/upgrade-in-place-from-lts-to-pro.rst
+++ b/google/google-how-to/gce/upgrade-in-place-from-lts-to-pro.rst
@@ -5,63 +5,87 @@ If your production environment is based on Ubuntu LTS and you need the premium s
 
 1. Stop your machine:
 
-.. code::
+   .. code::
 
-    gcloud compute instances stop $INSTANCE_NAME
+       gcloud compute instances stop $INSTANCE_NAME
 
 2. Append an Ubuntu Pro license to the disk:
 
-.. code::
+   .. code::
 
-    gcloud beta compute disks update $INSTANCE_NAME --zone=$ZONE --update-user-licenses=”LICENSE_URI”
+       gcloud beta compute disks update $INSTANCE_NAME --zone=$ZONE \
+           --replace-licenses=$PREVIOUS_LICENSE_URI,$NEW_LICENSE_URI
 
-where,
+   where
 
-* INSTANCE_NAME: is the name of the instance (boot disk) to append the license to
-* ZONE: is the zone containing the instance 
-* LICENSE_URI: is the license URI for the Pro version that you are upgrading to. If your VM runs Ubuntu 16.04 LTS, you need to upgrade to Ubuntu Pro 16.04 LTS. Choose the appropriate URI from: 
+   * ``$INSTANCE_NAME`` is the name of the instance (boot disk) to append the license to;
+   * ``$ZONE`` is the zone containing the instance;
+   * ``$PREVIOUS_LICENSE_URI`` is the license URI for the non-Pro version on your VM; and
+   * ``$NEW_LICENSE_URI`` is the license URI for the Pro version that you are upgrading to.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 20 50
+   You can only update to Pro for the same Ubuntu series. If your VM runs Ubuntu 16.04 LTS, you need to upgrade to Ubuntu Pro 16.04 LTS.
 
-   * - **Version**
-     - **License URI**
-   * - Ubuntu Pro 16.04 LTS
-     - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-1604-lts``
-   * - Ubuntu Pro 18.04 LTS
-     - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-1804-lts``
-   * - Ubuntu Pro 20.04 LTS
-     - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2004-lts``
-   * - Ubuntu Pro 22.04 LTS
-     - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2204-lts``
-   * - Ubuntu Pro 24.04 LTS
-     - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2404-lts``
+   For ``$PREVIOUS_LICENSE_URI`` choose the appropriate URI from:
 
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 50
 
-3. Start the machine
+      * - **Version**
+        - **License URI**
+      * - Ubuntu 16.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-1604-lts``
+      * - Ubuntu 18.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-1804-lts``
+      * - Ubuntu 20.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-2004-lts``
+      * - Ubuntu 22.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-2204-lts``
+      * - Ubuntu 24.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-2404-lts``
 
-.. code::
+   For ``$NEW_LICENSE_URI`` choose the appropriate URI from:
 
-    gcloud compute instances start $INSTANCE_NAME
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 50
 
-SSH into your machine and verify the upgrade by running:
+      * - **Version**
+        - **License URI**
+      * - Ubuntu Pro 16.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-1604-lts``
+      * - Ubuntu Pro 18.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-1804-lts``
+      * - Ubuntu Pro 20.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2004-lts``
+      * - Ubuntu Pro 22.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2204-lts``
+      * - Ubuntu Pro 24.04 LTS
+        - ``https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/licenses/ubuntu-pro-2404-lts``
 
-.. code::
+3. Start the machine:
 
-    pro status
+   .. code::
 
-The output should show the different services available and their current status. Something like:
+       gcloud compute instances start $INSTANCE_NAME
 
-.. code::
+4. SSH into your machine and verify the upgrade by running:
 
-    SERVICE          ENTITLED  STATUS    DESCRIPTION
-    esm-apps         yes       enabled   Expanded Security Maintenance for Applications
-    esm-infra        yes       enabled   Expanded Security Maintenance for Infrastructure
-    fips             yes       disabled  NIST-certified core packages
-    fips-updates     yes       disabled  NIST-certified core packages with priority security updates
-    livepatch        yes       enabled   Canonical Livepatch service
-    usg              yes       disabled  Security compliance and audit tools
+   .. code::
+
+       pro status
+
+   The output should show the different services available and their current status. Something like:
+
+   .. code::
+
+       SERVICE          ENTITLED  STATUS    DESCRIPTION
+       esm-apps         yes       enabled   Expanded Security Maintenance for Applications
+       esm-infra        yes       enabled   Expanded Security Maintenance for Infrastructure
+       fips             yes       disabled  NIST-certified core packages
+       fips-updates     yes       disabled  NIST-certified core packages with priority security updates
+       livepatch        yes       enabled   Canonical Livepatch service
+       usg              yes       disabled  Security compliance and audit tools
 
 
 For comprehensive instructions, please refer to the official Google Cloud documentation for `upgrading to Pro`_.


### PR DESCRIPTION
Google is rolling out mutable licenses which allow changing the license
of the boot disk. Google has asked us to use this new mechanism for
in-place upgrades to Pro.

What current instructions describe is appending Pro license to the
`userLicenses` field of the boot disk, but not changing its `license`
field. The new approach modifies the `license` field.

In addition to describe new mechanisms, some style changes were made:

  1. consistent variable references (FOO vs $FOO, and monospace)

  2. formatting of lists

  3. make the content below numbered list items actually belong to those
     items

[1] https://community.cochrane.org/style-manual/formatting/lists
