### PR TITLE
Link to an external guide instead of copying content to avoid CI errors

### DIFF
--- a/aws/aws-how-to/instances/launch-ubuntu-desktop.rst
+++ b/aws/aws-how-to/instances/launch-ubuntu-desktop.rst
@@ -62,7 +62,7 @@ After logging into your server, execute the commands below to install the Ubuntu
 
 .. code:: bash
 
-    sudo apt-get update && apt-get upgrade -y
+    sudo apt-get update && sudo apt-get upgrade -y
     sudo apt-get install -y ubuntu-desktop
     sudo snap install snap-store --edge
     sudo reboot

--- a/oci/oci-explanation/ubuntu-oci-container.rst
+++ b/oci/oci-explanation/ubuntu-oci-container.rst
@@ -6,7 +6,7 @@ Ubuntu OCI container images
 The `Open Container Initiative (OCI) <https://opencontainers.org/>`_ establishes standards for constructing container 
 images that can be reliably installed across a variety of compliant host environments.
 
-Ubuntu’s `LTS Docker Image Portfolio <https://ubuntu.com/security/docker-images>`_ 
+Ubuntu’s `LTS Docker Image Portfolio <https://ubuntu.com/containers>`_ 
 provides OCI-compliant images that receive stable security updates and predictable 
 software updates, ensuring consistency in both maintenance schedule and operational 
 interfaces for the underlying foundation your software builds on.

--- a/oci/oci-how-to/enable-pro-services.rst
+++ b/oci/oci-how-to/enable-pro-services.rst
@@ -1,3 +1,0 @@
-.. _oci-how-to-enable-pro-services:
-
-.. include:: /_external/enable-pro-services.rst

--- a/oci/oci-how-to/index.rst
+++ b/oci/oci-how-to/index.rst
@@ -21,10 +21,7 @@ Ubuntu Pro
 
 Learn how to build your own Ubuntu Pro container image from a regular Ubuntu container image.
 
-.. toctree::
-   :maxdepth: 1
-
-   Enable Ubuntu Pro services in a Dockerfile <enable-pro-services>
+* `Enable Ubuntu Pro services in a Dockerfile`_
 
 
 Deployments
@@ -48,3 +45,5 @@ information to add (whether it is a tutorial, a guide, or something else), this 
    :maxdepth: 1
 
    contribute-to-these-docs
+
+.. _Enable Ubuntu Pro services in a Dockerfile: https://documentation.ubuntu.com/pro-client/en/latest/howtoguides/enable_in_dockerfile/


### PR DESCRIPTION
Also correct a link which was getting redirected.