### PR TITLE
Configure slug for each project under docs.ubuntu.com

### DIFF
--- a/docs/all-clouds/conf.py
+++ b/docs/all-clouds/conf.py
@@ -51,6 +51,13 @@ html_context = {
     # https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
     'sequential_nav': "both"
 }
+
+
+# If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = 'public-cloud'
+
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: "explanation/old-name.html": "../how-to/prettify.html",
 redirects = {

--- a/docs/aws/conf.py
+++ b/docs/aws/conf.py
@@ -60,6 +60,11 @@ html_context = {
     'sequential_nav': "both"
 }
 
+# If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = 'aws'
+
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: "explanation/old-name.html": "../how-to/prettify.html",
 redirects = {

--- a/docs/azure/conf.py
+++ b/docs/azure/conf.py
@@ -61,6 +61,12 @@ html_context = {
     'sequential_nav': "both"
 }
 
+# If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = 'azure'
+
+
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: "explanation/old-name.html": "../how-to/prettify.html",
 redirects = {

--- a/docs/google/conf.py
+++ b/docs/google/conf.py
@@ -60,6 +60,11 @@ html_context = {
     'sequential_nav': "both"
 }
 
+# If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = 'gcp'
+
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: "explanation/old-name.html": "../how-to/prettify.html",
 redirects = {

--- a/docs/oci/conf.py
+++ b/docs/oci/conf.py
@@ -47,6 +47,11 @@ html_context = {
     "sequential_nav": "both",
 }
 
+# If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = 'oci-registries'
+
 # These docs reuse some content from other docs
 pro_client_docs = {
     "enable-pro-services.rst": "https://raw.githubusercontent.com/canonical/ubuntu-pro-client/docs/docs/howtoguides/enable_in_dockerfile.rst",

--- a/docs/public-images/conf.py
+++ b/docs/public-images/conf.py
@@ -60,6 +60,11 @@ html_context = {
     'sequential_nav': "both"
 }
 
+# If your documentation is hosted on https://docs.ubuntu.com/,
+#       uncomment and update as needed.
+
+slug = 'public-images'
+
 # Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 # For example: "explanation/old-name.html": "../how-to/prettify.html",
 redirects = {}


### PR DESCRIPTION
This is required for the notfound extension to function correctly and render a valid page on encountering a 404 error.