### PR TITLE
feat(AWS) Add documentation on how to find images using describe-images

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -62,6 +62,7 @@ config
 CPC
 cpc
 CPUs
+CreationDate
 cron
 cryptographic
 cryptographically
@@ -321,6 +322,7 @@ softwares
 sqlcmd
 SquashFS
 SRU
+ssd
 SSH
 sshd
 SSHD


### PR DESCRIPTION
Our current documentation for finding EC2 images focuses solely on SSM parameters. while this is great for many use cases, there is a very large user base that prefers to use describe-images.