### PR TITLE
Free azure updates

### DIFF
--- a/docs/azure/azure-how-to/instances/find-ubuntu-images.rst
+++ b/docs/azure/azure-how-to/instances/find-ubuntu-images.rst
@@ -56,21 +56,33 @@ Ubuntu 22.04 LTS - Jammy Jellyfish
 | Quick start (China): `22.04 LTS on Azure China <https://portal.azure.cn/#create/canonical.0001-com-ubuntu-server-jammy22_04-lts-ARM>`_
 
 .. list-table::
-   :widths: 10 9 50
+   :widths: 10 10 9 50
    :header-rows: 1
 
-   * - **Architecture**
+   * - **Flavor**
+     - **Architecture**
      - **Hyper-V Generation**
      - **URN**
-   * - AMD64
+   * - Server
+     - AMD64
      - Gen1
      - ``Canonical:0001-com-ubuntu-server-jammy:22_04-lts:latest``
-   * - AMD64
+   * - Server
+     - AMD64
      - Gen2
      - ``Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest``
-   * - Arm64
+   * - Server
+     - Arm64
      - Gen2
      - ``Canonical:0001-com-ubuntu-server-jammy:22_04-lts-arm64:latest``
+   * - Minimal
+     - AMD64
+     - Gen1
+     - ``Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts:latest``
+   * - Minimal
+     - AMD64
+     - Gen2
+     - ``Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:latest``
 
 Interim releases
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added missing free minimal URNs to documentation. Tested/verified locally using readme instructions. Note that we do not have minimal arm64 images for Jammy at this time.