### PR TITLE
feat(aws): document allowed AMI usage in find-image page

### DIFF
--- a/docs/aws/aws-how-to/instances/find-ubuntu-images.rst
+++ b/docs/aws/aws-how-to/instances/find-ubuntu-images.rst
@@ -282,7 +282,7 @@ You can also add Canonical's OwnerId to allow list:
 
    aws ec2 modify-allowed-images --image-owner $OWNER_ID
 
-By running the command above, you only allow Canonical ubuntu images and ensure that instances can only be launched with verified, official images.
+By running the command above, you only allow Canonical Ubuntu images and ensure that instances can only be launched with verified, official images.
 
 See the AWS announcement for more details on the `Allowed AMIs feature`_.
 


### PR DESCRIPTION
Add instructions for restricting launches to Canonical's official Ubuntu images using the allowed AMIs feature.

Includes example for adding Canonical's owner ID to the allow list and for listing Ubuntu AMIs from that owner
