### PR TITLE
feat(public-images): CPC-7526 Adding a how-to guide to verify an ISO image using checksum

### DIFF
--- a/docs/.sphinx/.wordlist.txt
+++ b/docs/.sphinx/.wordlist.txt
@@ -11,12 +11,10 @@ DCO
 Diátaxis
 Dqlite
 dropdown
-EB
 EBS
 EKS
 enablement
 favicon
-FDDC
 Furo
 Git
 GitHub
@@ -245,12 +243,14 @@ Containerd
 Coturn
 Cryptographic
 Devel
+Discourse
 Endian
 Endianness
 Fluentd
 GraphQL
 HAProxy
 HAcluster
+HomeBrew
 Imagecraft
 Infiniband
 Influxdb

--- a/docs/.sphinx/.wordlist.txt
+++ b/docs/.sphinx/.wordlist.txt
@@ -11,10 +11,12 @@ DCO
 Diátaxis
 Dqlite
 dropdown
+EB
 EBS
 EKS
 enablement
 favicon
+FDDC
 Furo
 Git
 GitHub
@@ -316,8 +318,10 @@ armhf
 autopkgtest
 cURL
 containeragent
+coreutils
 dqlite
 dsc
+gpg
 init
 jQuery
 juju

--- a/docs/public-images/public-images-how-to/index.rst
+++ b/docs/public-images/public-images-how-to/index.rst
@@ -16,6 +16,7 @@ Guides related to QCOW images:
 
 Other miscellaneous guides:
 
+- :ref:`verify-image-checksum`
 - :ref:`use-local-cloud-init-ds`
 - :ref:`run-an-ova-using-virtualbox`
 
@@ -27,5 +28,6 @@ Other miscellaneous guides:
    Run a Vagrant box<run-a-vagrant-box>
    Launch QCOW images using libvirt<launch-with-libvirt>
    Launch QCOW images using QEMU<launch-qcow-with-qemu>
+   Verify an image checksum<verify-image-checksum>
    Create a local cloud-init datasource<use-local-cloud-init-ds>
    Run an OVA using VirtualBox<run-an-ova-using-virtualbox>

--- a/docs/public-images/public-images-how-to/verify-image-checksum.rst
+++ b/docs/public-images/public-images-how-to/verify-image-checksum.rst
@@ -6,9 +6,10 @@ Verify an image checksum
 For every `ubuntu cloud image`_, Canonical provides a corresponding SHA256 checksum. 
 These checksums help reassure that the image you have downloaded is not corrupted in any way and that it is an authentic image that hasn't been tampered with.
 
-We will go over how you can use the provided checksums to verify the authenticity of your downloaded image.
+We will go over how you can use the provided checksums to verify the authenticity of your downloaded image. You can use these steps to verify other related files 
+such as changelog files, tarballs, manifests, etc.
 
-Installing the necessary packages
+Install the necessary packages
 ---------------------------------
 The packages you will require are ``sha256sum``, ``md5sum`` and ``gpg``. Follow the guide corresponding to your system.
 
@@ -18,7 +19,7 @@ These are part of the ``coreutils`` and ``gnupg`` packages, which are installed 
 
 MacOS
 ~~~~~
-Install the latest GnuPG and coreutils
+Install the latest GnuPG and coreutils using `HomeBrew`_:
 
 .. code:: bash
 
@@ -26,7 +27,7 @@ Install the latest GnuPG and coreutils
 
 Windows
 ~~~~~~~
-If you are using bash on Windows 10, these tools are part of the default install.
+If you are using `Ubuntu on WSL`_, these tools are part of the default install.
 
 Verify the installed packages
 -----------------------------
@@ -39,12 +40,12 @@ Verify the installed packages
 Download the relevant file and keys
 -----------------------------------
 
-Make sure you have the ``SHA256SUMS`` and ``SHA256SUMS.gpg`` files corresponding to the ISO image you have downloaded available locally.
+Make sure you have the ``SHA256SUMS`` and ``SHA256SUMS.gpg`` files corresponding to the cloud image (``.img`` file) you have downloaded available locally.
 You can find these files at https://cloud-images.ubuntu.com
 
-**Note:** The following part of this how-to assumes you have the ISO image, SHA256SUMS and SHA256SUMS.gpg files in the current working directory.
+**Note:** The following part of this how-to assumes you have the cloud image (``.img`` file) image, SHA256SUMS and SHA256SUMS.gpg files in the current working directory
 
-Check if you have the Public key
+Check if you have the public key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: bash
@@ -59,15 +60,15 @@ If the public keys aren't present in your system, you will get an error message 
     gpg:                using RSA key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
     gpg: Can't check signature: No public key
 
-Using these ID numbers (*D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81 in the example*), we can request them from the Ubuntu key server.
+Using these ID numbers (``D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81`` here), we can request them from the Ubuntu key server.
 
 
-Note: Since the ID numbers are hexadecimal, we prefix them with a ``0x``
+Ubuntu Enterprise uses the signing key with the public id ``D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81``
 
 
 .. code:: bash
 
-    gpg --keyid-format long --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xD2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+    gpg --keyid-format long --keyserver hkp://keyserver.ubuntu.com --recv-keys D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
 
 
 
@@ -75,7 +76,17 @@ You can now inspect the key fingerprints by running:
 
 .. code:: bash
 
-    gpg --keyid-format long --list-keys --with-fingerprint 0xD2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+    $ gpg --keyid-format long --list-keys --with-fingerprint D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+
+
+Which should output a message similar to the following:
+
+
+.. code:: text
+
+    pub   rsa4096/1A5D6C4C7DB87C81 2009-09-15 [SC]
+        Key fingerprint = D2EB 4462 6FDD C30B 513D  5BB7 1A5D 6C4C 7DB8 7C81
+    uid                 [ unknown] UEC Image Automatic Signing Key <cdimage@ubuntu.com>
 
 
 Verify the checksum and image
@@ -84,7 +95,7 @@ Verify the checksum and image
 Now that we have the tools and keys required, we can verify our image. We will perform the following steps:
 
 #. Verify that the checksum file is authentic
-#. Generate a checksum of the ISO image and match it with the authenticated checksum file
+#. Generate a checksum of the cloud image (``.img`` file) image and match it with the authenticated checksum file
 
 Verify the checksum file
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -106,13 +117,13 @@ In the output, you should see something like this:
     Primary key fingerprint: D2EB 4462 6FDD C30B 513D  5BB7 1A5D 6C4C 7DB8 7C81
 
 
-Verify the ISO image
-~~~~~~~~~~~~~~~~~~~~
+Verify the cloud image (``.img`` file) image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Finally, now that we have an authentic checksum file, we can generate a SHA256 checksum of the image and compare it with the file we just authenticated.
 
 
-Make sure you preserve the filename of the original downloaded ISO image file
+**Note:** Make sure you preserve the filename of the original downloaded cloud image (``.img`` file) image file
 
 .. code:: bash
 
@@ -125,4 +136,30 @@ The output should look similar to the following:
     questing-server-cloudimg-amd64.img: OK
 
 
+If you have the corresponding manifests, changelogs or any other relevant files,
+they can be verified too, as long as they are in same working directory
+
+.. code:: text
+
+    questing-server-cloudimg-amd64-root.manifest: OK
+    questing-server-cloudimg-amd64.img: OK
+    questing-server-cloudimg-amd64.daily.20250921.20250926.image_changelog.json: OK
+    questing-server-cloudimg-amd64-lxd.tar.xz: OK
+
+
+Additional Reading
+------------------
+
+For more information, you can checkout the following resources
+
+#. `Ubuntu Discourse`_
+#. `SHA-2 checksum`_
+#. `GnuPG`_
+
+
 .. _`ubuntu cloud image`: https://cloud-images.ubuntu.com
+.. _`Ubuntu on WSL`: https://documentation.ubuntu.com/wsl/stable/
+.. _`HomeBrew`: https://brew.sh/
+.. _`GnuPG`: https://www.gnupg.org/gph/en/manual/x135.html
+.. _`Ubuntu Discourse`: https://discourse.ubuntu.com/
+.. _`SHA-2 checksum`: https://en.wikipedia.org/wiki/SHA-2

--- a/docs/public-images/public-images-how-to/verify-image-checksum.rst
+++ b/docs/public-images/public-images-how-to/verify-image-checksum.rst
@@ -1,0 +1,128 @@
+.. _verify-image-checksum:
+
+Verify an image checksum
+========================
+
+For every `ubuntu cloud image`_, Canonical provides a corresponding SHA256 checksum. 
+These checksums help reassure that the image you have downloaded is not corrupted in any way and that it is an authentic image that hasn't been tampered with.
+
+We will go over how you can use the provided checksums to verify the authenticity of your downloaded image.
+
+Installing the necessary packages
+---------------------------------
+The packages you will require are ``sha256sum``, ``md5sum`` and ``gpg``. Follow the guide corresponding to your system.
+
+Ubuntu
+~~~~~~
+These are part of the ``coreutils`` and ``gnupg`` packages, which are installed by default.
+
+MacOS
+~~~~~
+Install the latest GnuPG and coreutils
+
+.. code:: bash
+
+    brew install gnupg coreutils
+
+Windows
+~~~~~~~
+If you are using bash on Windows 10, these tools are part of the default install.
+
+Verify the installed packages
+-----------------------------
+.. code:: bash
+
+    gpg --list-keys
+    md5sum --version
+    sha256sum --version
+
+Download the relevant file and keys
+-----------------------------------
+
+Make sure you have the ``SHA256SUMS`` and ``SHA256SUMS.gpg`` files corresponding to the ISO image you have downloaded available locally.
+You can find these files at https://cloud-images.ubuntu.com
+
+**Note:** The following part of this how-to assumes you have the ISO image, SHA256SUMS and SHA256SUMS.gpg files in the current working directory.
+
+Check if you have the Public key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    gpg --keyid-format long --verify SHA256SUMS.gpg SHA256SUMS
+
+If the public keys aren't present in your system, you will get an error message similar to the following
+
+.. code:: text
+
+    gpg: Signature made Tue Sep 30 13:04:34 2025 EDT
+    gpg:                using RSA key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+    gpg: Can't check signature: No public key
+
+Using these ID numbers (*D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81 in the example*), we can request them from the Ubuntu key server.
+
+
+Note: Since the ID numbers are hexadecimal, we prefix them with a ``0x``
+
+
+.. code:: bash
+
+    gpg --keyid-format long --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xD2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+
+
+
+You can now inspect the key fingerprints by running:
+
+.. code:: bash
+
+    gpg --keyid-format long --list-keys --with-fingerprint 0xD2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+
+
+Verify the checksum and image
+-----------------------------
+
+Now that we have the tools and keys required, we can verify our image. We will perform the following steps:
+
+#. Verify that the checksum file is authentic
+#. Generate a checksum of the ISO image and match it with the authenticated checksum file
+
+Verify the checksum file
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    gpg --keyid-format long --verify SHA256SUMS.gpg SHA256SUMS
+
+
+In the output, you should see something like this:
+
+.. code:: text
+
+    gpg: Signature made Tue Sep 30 13:04:34 2025 EDT
+    gpg:                using RSA key D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81
+    gpg: Good signature from "UEC Image Automatic Signing Key <cdimage@ubuntu.com>" [unknown]
+    gpg: WARNING: This key is not certified with a trusted signature!
+    gpg:          There is no indication that the signature belongs to the owner.
+    Primary key fingerprint: D2EB 4462 6FDD C30B 513D  5BB7 1A5D 6C4C 7DB8 7C81
+
+
+Verify the ISO image
+~~~~~~~~~~~~~~~~~~~~
+
+Finally, now that we have an authentic checksum file, we can generate a SHA256 checksum of the image and compare it with the file we just authenticated.
+
+
+Make sure you preserve the filename of the original downloaded ISO image file
+
+.. code:: bash
+
+    sha256sum -c SHA256SUMS 2>&1 | grep OK
+
+The output should look similar to the following:
+
+.. code:: text
+
+    questing-server-cloudimg-amd64.img: OK
+
+
+.. _`ubuntu cloud image`: https://cloud-images.ubuntu.com


### PR DESCRIPTION
This PR adds a how-to page on using checksum to verify ISO images downloaded from https://cloud-images.ubuntu.com/

I referred the [Ubuntu docs](https://ubuntu.com/tutorials/how-to-verify-ubuntu#1-overview) to get started and added in my own code blocks and thoughts

I've attached a PDF version of the newly added page to view how the page is rendered
[Verify an image checksum.pdf](https://github.com/user-attachments/files/22663945/Verify.an.image.checksum.-.Ubuntu.Public.Images.documentation.pdf)