### PR TITLE
docs(aws): add EKS 1.35 to find images page

### DIFF
--- a/docs/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/docs/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -32,6 +32,8 @@ Ubuntu 24.04 LTS for EKS 1.33,AMD64,``prod-vipjxy4ycab24``,✓
 Ubuntu 24.04 LTS for EKS 1.33,ARM64,``prod-6ekvrmao3h5aq``,✓
 Ubuntu 24.04 LTS for EKS 1.34,AMD64,``prod-yekviic7ygm5u``,✓
 Ubuntu 24.04 LTS for EKS 1.34,ARM64,``prod-ock7ogk6tq4zk``,✓
+Ubuntu 24.04 LTS for EKS 1.35,AMD64,``prod-qrmo5s6td573i``,✓
+Ubuntu 24.04 LTS for EKS 1.35,ARM64,``prod-wv777awwyqv22``,✓
 Ubuntu Pro 20.04 LTS for EKS 1.29,AMD64,``prod-4yrqysyuk6vts``,✓
 Ubuntu Pro 20.04 LTS for EKS 1.29,ARM64,``prod-mu642qufmvg5i``,✓
 Ubuntu Pro 22.04 LTS for EKS 1.29,AMD64,``prod-zhspprfykjuvy``,✓
@@ -54,3 +56,5 @@ Ubuntu Pro 24.04 LTS for EKS 1.33,AMD64,``prod-iw7flxdfclfke``,✓
 Ubuntu Pro 24.04 LTS for EKS 1.33,ARM64,``prod-ii4giewcdfc6a``,✓
 Ubuntu Pro 24.04 LTS for EKS 1.34,AMD64,``prod-64vhgzqv5q5bu``,✓
 Ubuntu Pro 24.04 LTS for EKS 1.34,ARM64,``prod-omze7cslqlm3a``,✓
+Ubuntu Pro 24.04 LTS for EKS 1.35,AMD64,``prod-dzbeduymf5sgg``,✓
+Ubuntu Pro 24.04 LTS for EKS 1.35,ARM64,``prod-jy7g3vz4syi2w``,✓

--- a/docs/aws/aws-how-to/instances/find-ubuntu-images.rst
+++ b/docs/aws/aws-how-to/instances/find-ubuntu-images.rst
@@ -53,7 +53,7 @@ To find images on AWS, you can use the `SSM Parameter Store`_, the `describe-ima
                aws ssm get-parameters --names /aws/service/canonical/ubuntu/{eks_product}/{release}/{k8s}/stable/{serial}/{arch}/hvm/{vol}/ami-id
                :eks_product: eks, eks-pro
                :release: noble, jammy
-               :k8s: 1.34, 1.33, 1.32, 1.31
+               :k8s: 1.35, 1.34, 1.33, 1.32, 1.31
                :serial: current, 20250804, 20240115
                :arch: amd64, arm64
                :vol: ebs-gp3{release:noble}, ebs-gp2{release:jammy}
@@ -128,7 +128,7 @@ To find images on AWS, you can use the `SSM Parameter Store`_, the `describe-ima
                :eks_product: eks, eks-pro
                :release: noble, jammy
                :suite: 24.04{release:noble}, 22.04{release:jammy}
-               :k8s: 1.34, 1.33, 1.32, 1.31
+               :k8s: 1.35, 1.34, 1.33, 1.32, 1.31
                :serial: *, 20250804, 20240115
                :arch: amd64, arm64
                :vol: ssd-gp3{release:noble}, ssd{release:jammy}


### PR DESCRIPTION
EKS 1.35 is available and should be included in our product table and dropdown for finding images on AWS.