### PR TITLE
feat(GCE): Add docs around linux-gcp vs. linux-gcp-64k

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -11,6 +11,7 @@ AgentBaker
 AIB
 AKS
 allocatable
+Altra
 AmazonLinux
 amd
 ami
@@ -30,6 +31,7 @@ AskUbuntu
 Authorize
 aws
 awspub
+Axion
 AzGPS
 backend
 backends
@@ -248,6 +250,7 @@ namespace
 namespaces
 nano
 natively
+needrestart
 netfilter
 NIC
 NICs
@@ -275,6 +278,7 @@ OpenShift
 OpenSSH
 openssl
 OpenStack
+os
 OVA
 OVAs
 OVF
@@ -311,6 +315,7 @@ reStructuredText
 RHCOS
 RHEL
 riscv
+rmadison
 rollout
 rootfs
 RSA
@@ -376,6 +381,7 @@ UbuntuPro
 udev
 UEFI
 UI
+uname
 uncompress
 unlaunched
 unminimize

--- a/docs/google/google-how-to/gce/arm64-on-google-cloud.rst
+++ b/docs/google/google-how-to/gce/arm64-on-google-cloud.rst
@@ -1,0 +1,37 @@
+`arm64` on Google Cloud
+==========================
+
+## `arm64` platforms
+Google Cloud currently provides two different CPU platforms for `arm64`: Ampere Altra (via the "Tau" `T2A` machine type) 
+and Google's own Axion (via the `N4A` and `C4A` machine types).
+
+## `64k` page kernels
+
+From Jammy Jellyfish 22.04 onwards, Ubuntu provides two variant kernels to run `arm64`: `linux-gcp` and `linux-gcp-64k`.
+"Standard" Ubuntu images on Google Cloud come preinstalled with the default `linux-gcp` kernel (see `rmadison linux-gcp` for details) but
+the "accelerator" Ubuntu image line has `linux-gcp-64k`. To see the latest accelerator-based images available, use `gcloud compute images list --project=ubuntu-os-accelerator-images --no-standard-images`.
+
+**N.B:** The `linux-gcp` kernel will work on *both* CPU platforms, but `linux-gcp-64k` *will not* work on `T2A` machine types.
+
+## Changing the installed kernel
+
+Should you wish to swap from the default kernel to the `64k` page variant (or vice versa), run:
+
+```
+sudo apt update
+sudo apt install linux-gcp-64k
+```
+after installation a pop-up courtesy of `needrestart` will appear recommending you reboot.
+You must reboot the instance for the kernel to properly install:
+```
+sudo reboot
+```
+
+When you log back into the instance, run `uname -a` to confirm the new kernel has indeed installed.
+
+## More information
+
+For more information on the different use cases of these two kernels, see `these docs`_.
+
+
+.. _`these docs`: https://documentation.ubuntu.com/server/explanation/installation/choosing-between-the-arm64-and-arm64-largemem-installer-options/index.html

--- a/docs/google/google-how-to/gce/index.rst
+++ b/docs/google/google-how-to/gce/index.rst
@@ -12,6 +12,7 @@ Launching different types of instances:
 * :doc:`Find images <find-ubuntu-images>`
 * :doc:`Create instances <create-different-instance-types>`
 * :doc:`Launch a desktop <launch-ubuntu-desktop>`
+* :doc:`ARM64 on Google Cloud <arm64-on-google-cloud>`
 
 Creating golden images and customized containers:
 
@@ -41,3 +42,4 @@ Administrative operations:
    Enable Pro features <enable-pro-features>   
    Upgrade from Focal to Jammy <upgrade-from-focal-to-jammy>
    Set hostname <set-hostname-using-cloudinit>
+   ARM64 on Google Cloud <arm64-on-google-cloud>

--- a/docs/google/google-how-to/index.rst
+++ b/docs/google/google-how-to/index.rst
@@ -20,6 +20,7 @@ While using Ubuntu on GCP, you'll need to perform tasks such as finding the righ
 * :doc:`Enable Pro features <gce/enable-pro-features>`
 * :doc:`Upgrade from Focal to Jammy <gce/upgrade-from-focal-to-jammy>`
 * :doc:`Set hostname <gce/set-hostname-using-cloudinit>`
+* :doc:`ARM64 on Google Cloud <gce/arm64-on-google-cloud>`
 
 GKE and Kubernetes
 ------------------

--- a/docs/google/index.rst
+++ b/docs/google/index.rst
@@ -29,7 +29,7 @@ In this documentation
       - :doc:`GCP optimizations <google-explanation/canonical-offerings>` • :doc:`Packaged Google agents <google-explanation/guest-agents>` •  
       
     * - **Finding and launching images**
-      - :doc:`Find images <google-how-to/gce/find-ubuntu-images>` • :doc:`Create instances <google-how-to/gce/create-different-instance-types>` • :doc:`Launch a desktop <google-how-to/gce/launch-ubuntu-desktop>` 
+      - :doc:`Find images <google-how-to/gce/find-ubuntu-images>` • :doc:`Create instances <google-how-to/gce/create-different-instance-types>` • :doc:`Launch a desktop <google-how-to/gce/launch-ubuntu-desktop>` • :doc:`ARM64 on Google Cloud <google-how-to/gce/arm64-on-google-cloud>`
       
     * - **Upgrades and maintenance**
       - :doc:`Switch between LTS and Pro <google-how-to/gce/upgrade-in-place-from-lts-to-pro>` • :doc:`Enable Ubuntu Pro features <google-how-to/gce/enable-pro-features>` • :doc:`Upgrade from Focal to Jammy <google-how-to/gce/upgrade-from-focal-to-jammy>` 


### PR DESCRIPTION
As we install different kernel variants depending on the image type let's add some public documentation saying as such. The docs here are very Google specific but at the end there is a link to the more generic server docs where the different between "normal" vs. 64k page is better described.

Refs: CPC-7480