### PR TITLE
fix: CVM kernels do roll

### DIFF
--- a/docs/all-clouds/all-clouds-explanation/kernels-on-the-cloud.rst
+++ b/docs/all-clouds/all-clouds-explanation/kernels-on-the-cloud.rst
@@ -27,7 +27,7 @@ This model provides the latest upstream bug fixes and performance improvements a
 
 This package is the default for at least Ubuntu Server and Ubuntu Minimal images across all clouds.
 
-.. note:: Some Ubuntu images do not use this package by default. Products like Ubuntu Pro FIPS and Ubuntu CVM generally have specifically tailored kernel variants that do not follow the rolling kernel model, and instead focus on bug fixes and performance updates to ensure more environmental stability for that product, similar to the behavior of the :ref:`LTS kernel package <lts-kernel>`.
+.. note:: Some Ubuntu images do not use this package by default. Products like Ubuntu Pro FIPS have specifically tailored kernel variants that do not follow the rolling kernel model, and instead focus on bug fixes and performance updates to ensure more environmental stability for that product, similar to the behavior of the :ref:`LTS kernel package <lts-kernel>`.
 
 How kernel rolling works
 ________________________


### PR DESCRIPTION
TIL (while investigating something random) that the CVM kernels do not use the base kernel version launched with the release. i.e. Azure Jammy CVM images launch with linux-azure-fde-6.8, not linux-azure-fde (which features version 5.15).