### PR TITLE
feat: Add 26.04 marketplace identifiers

### DIFF
--- a/docs/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
+++ b/docs/aws/aws-how-to/instances/aws-marketplace-identifiers.csv
@@ -17,6 +17,14 @@ Ubuntu 25.10,AMD64,``prod-dbwuezdrdb7iy``,✓
 Ubuntu 25.10,ARM64,``prod-ai5xvos27zaaa``,✓
 Minimal Ubuntu 25.10,AMD64,``prod-ubgcoqmfkuwdc``,✓
 Minimal Ubuntu 25.10,ARM64,``prod-3xdacybxd6mua``,✓
+Ubuntu 26.04,AMD64,``prod-qls2nau5pwovi``,✓
+Ubuntu 26.04,ARM64,``prod-vnoa6ytsnfhds``,✓
+Ubuntu Pro 26.04 LTS,AMD64,``prod-3lrv73g7p53mc``,✓
+Ubuntu Pro 26.04 LTS,ARM64,``prod-duirjvvxggjl4``,✓
+Minimal Ubuntu 26.04,AMD64,``prod-t2g5uxqa5bm72``,✓
+Minimal Ubuntu 26.04,ARM64,``prod-fijpm2fiyfnlw``,✓
+Minimal Ubuntu Pro 26.04 LTS,AMD64,``prod-dvsie5mrs3ma2``,✓
+Minimal Ubuntu Pro 26.04 LTS,ARM64,``prod-qrdnkgcis7pdc``,✓
 Ubuntu Pro FIPS 16.04 LTS,AMD64,``prod-hykkbajyverq4``,✓
 Ubuntu Pro FIPS 18.04 LTS,AMD64,``prod-7izp2xqnddwdc``,✓
 Ubuntu Pro FIPS 20.04 LTS,AMD64,``prod-k6fgbnayirmrc``,✓


### PR DESCRIPTION
Resolute listings are public. Add 26.04
identifiers so customer can find images.