### PR TITLE
fix(aws): correctly reformat dropdown text on forced update

### DIFF
--- a/docs/_static/js/formatted-dropdown.js
+++ b/docs/_static/js/formatted-dropdown.js
@@ -33,32 +33,44 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         function updateDropdowns() {
-            selects.forEach(sel => {
-                const key = sel.dataset.key;
-                const field = widget.querySelector(`.dropdown-field[data-field="${key}"]`);
+            for (let pass = 0; pass < selects.length; pass++) {
+                let changed = false;
 
-                const prevValue = sel.value;
-                const available = computeAvailableValues(key);
+                selects.forEach(sel => {
+                    const key = sel.dataset.key;
+                    const field = widget.querySelector(`.dropdown-field[data-field="${key}"]`);
 
-                sel.innerHTML = available
-                    .map(o => `<option value="${o.value}">${o.value}</option>`)
-                    .join("");
+                    const prevValue = sel.value;
+                    const available = computeAvailableValues(key);
 
-                // Try to restore previous value
-                if (available.some(a => a.value === prevValue)) {
-                    sel.value = prevValue;
-                } else {
-                    // Otherwise pick first valid value
-                    sel.value = available[0]?.value;
+                    sel.innerHTML = available
+                        .map(o => `<option value="${o.value}">${o.value}</option>`)
+                        .join("");
+
+                    // Try to restore previous value
+                    if (available.some(a => a.value === prevValue)) {
+                        sel.value = prevValue;
+                    } else {
+                        // Otherwise pick first valid value
+                        sel.value = available[0]?.value;
+                    }
+
+                    if (sel.value !== prevValue) {
+                        changed = true;
+                    }
+
+                    // Hide the field if only one possible value
+                    if (available.length === 1) {
+                        field.style.display = "none";
+                    } else {
+                        field.style.display = "flex";
+                    }
+                });
+
+                if (!changed) {
+                    break;
                 }
-
-                // Hide the field if only one possible value
-                if (available.length === 1) {
-                    field.style.display = "none";
-                } else {
-                    field.style.display = "flex";
-                }
-            });
+            }
         }
 
         function updateOutput() {

--- a/docs/exts/formatted-dropdown.py
+++ b/docs/exts/formatted-dropdown.py
@@ -26,6 +26,8 @@ class FormattedDropdownDirective(Directive):
             return {"value": raw.strip(), "conditions": {}}
 
         value = m.group("val").strip()
+        if value == '""':
+            value = ""
         conds = m.group("conds")
         if not conds:
             return {"value": value, "conditions": {}}


### PR DESCRIPTION
Some combinations of values for the dropdown widget are not possible requiring a forced update. In some cases this only updated the main field and not dependent fields earlier in the string.