### PR TITLE
docs(oke): Remove OKE 1.32 and 1.33 from available releases 

### DIFF
--- a/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
+++ b/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
@@ -23,9 +23,6 @@ The following Ubuntu images are available for worker nodes on Oracle Kubernetes 
      - OKE Version
      - End of Life
    * - 22.04 (Jammy Jellyfish)
-     - 1.32.1
-     - 30 days after 1.35.1 OKE Release
-   * -
      - 1.33.1
      - 30 days after 1.36.1 OKE Release
    * -
@@ -36,9 +33,6 @@ The following Ubuntu images are available for worker nodes on Oracle Kubernetes 
      - 30 days after 1.38.1 OKE Release
 
    * - 24.04 (Noble Numbat)
-     - 1.32.1
-     - 30 days after 1.35.1 OKE Release
-   * -
      - 1.33.1
      - 30 days after 1.36.1 OKE Release
    * -

--- a/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
+++ b/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
@@ -23,9 +23,6 @@ The following Ubuntu images are available for worker nodes on Oracle Kubernetes 
      - OKE Version
      - End of Life
    * - 22.04 (Jammy Jellyfish)
-     - 1.33.1
-     - 30 days after 1.36.1 OKE Release
-   * -
      - 1.34.1
      - 30 days after 1.37.1 OKE Release
    * -
@@ -33,9 +30,6 @@ The following Ubuntu images are available for worker nodes on Oracle Kubernetes 
      - 30 days after 1.38.1 OKE Release
 
    * - 24.04 (Noble Numbat)
-     - 1.33.1
-     - 30 days after 1.36.1 OKE Release
-   * -
      - 1.34.1
      - 30 days after 1.37.1 OKE Release
    * -


### PR DESCRIPTION
Removing OKE 1.32 and 1.33 from available releases as they are now EOL