### PR TITLE
docs(oke): Add release for new OKE versions including new suite resolute

### DIFF
--- a/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
+++ b/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
@@ -35,6 +35,16 @@ The following Ubuntu images are available for worker nodes on Oracle Kubernetes 
    * -
      - 1.35.2
      - 30 days after 1.38.1 OKE Release
+   * -
+     - 1.36.1
+     - 30 days after 1.39.1 OKE Release
+
+   * - 26.04 (Resolute Raccoon)
+     - 1.35.2
+     - 30 days after 1.38.1 OKE Release
+   * -
+     - 1.36.1
+     - 30 days after 1.39.1 OKE Release
 
 
 Networking plugin availability


### PR DESCRIPTION
New OKE version 1.36.1 support for noble. New suite Resolute support for 1.35.2 and 1.36.1

**NOTE: MERGING IS BLOCKED UNTIL THESE IMAGES ARE AVAILABLE ON ORACLE CLOUD**