### PR TITLE
feat(GCP): add how-to for creating a GKE cluster with Ubuntu nodes

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -32,6 +32,7 @@ armhf
 ASIC
 AskUbuntu
 Authorize
+Autopilot
 aws
 awspub
 Axion
@@ -70,6 +71,7 @@ CloudSigma
 CNCF
 codename
 config
+containerd
 coreutils
 CPC
 cpc

--- a/docs/google/google-how-to/gke/create-gke-cluster-with-ubuntu-nodes.rst
+++ b/docs/google/google-how-to/gke/create-gke-cluster-with-ubuntu-nodes.rst
@@ -1,0 +1,149 @@
+.. meta::
+   :description: Learn how to create a Google Kubernetes Engine (GKE) cluster with Ubuntu nodes using the gcloud CLI, and verify the node OS image.
+
+
+Create a GKE cluster with Ubuntu nodes
+======================================
+
+`Google Kubernetes Engine`_ (GKE) is a managed Kubernetes service on Google Cloud
+that lets you deploy and manage containerized applications. Ubuntu can be used as
+the base operating system for GKE nodes, giving you a familiar, well-supported
+foundation for your workloads.
+
+Using Ubuntu for your GKE nodes provides several benefits:
+
+* **Flexible.** Ubuntu can be used across a variety of Kubernetes distributions, so
+  your teams get a standardized experience across multiple clouds, such as Azure
+  Kubernetes Service (AKS) and Amazon Elastic Kubernetes Service (EKS).
+* **Secure.** Timely updates and patches, building on Ubuntu's security track record.
+* **Stable.** Long-term support with a consistent, predictable lifecycle. Each GKE
+  version ships a customized version of Ubuntu that supports its latest features.
+* **Seamless.** A developer-friendly, smooth experience from development to production.
+
+This guide uses the `gcloud CLI tool`_ to create a cluster with Ubuntu nodes. To
+create a cluster from the Google Cloud console instead, refer to the `GKE
+documentation on creating clusters`_.
+
+
+Prerequisites
+-------------
+
+Before you begin, make sure that you have:
+
+* Installed and initialized the `gcloud CLI tool`_.
+* Installed ``kubectl`` and the ``gke-gcloud-auth-plugin`` authentication plugin.
+* Selected the project you want to work in:
+
+  .. code::
+
+    gcloud config set project <project-id>
+
+* Enabled the Kubernetes Engine API for your project:
+
+  .. code::
+
+    gcloud services enable container.googleapis.com
+
+
+Choose a cluster mode
+---------------------
+
+GKE offers two modes of operation: Autopilot and Standard. In Autopilot mode,
+Google manages the infrastructure for you, and you cannot manually select node image
+types. To explicitly configure and manage Ubuntu nodes, create a **Standard**
+cluster, which lets you customize your node pools and specify the ``UBUNTU_CONTAINERD``
+image type.
+
+
+Create a cluster with Ubuntu nodes
+----------------------------------
+
+Create a Standard cluster and set the node image type to Ubuntu with containerd
+using the ``--image-type`` flag:
+
+.. code::
+
+    gcloud container clusters create <cluster-name> \
+        --image-type UBUNTU_CONTAINERD \
+        --zone <zone> \
+        --num-nodes <number-of-nodes>
+
+.. note::
+   You can substitute ``--zone <zone>`` with ``--region <region>`` if you are deploying
+   a high-availability regional cluster.
+
+For example, to create a cluster named ``ubuntu-cluster`` with three nodes in the
+``us-central1-c`` zone:
+
+.. code::
+
+    gcloud container clusters create ubuntu-cluster \
+        --image-type UBUNTU_CONTAINERD \
+        --zone us-central1-c \
+        --num-nodes 3
+
+The ``UBUNTU_CONTAINERD`` image type corresponds to the "Ubuntu with containerd
+(ubuntu_containerd)" option in the Google Cloud console.
+
+
+Use Ubuntu nodes in a specific node pool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you already have an existing cluster, or want only specific node pools to run Ubuntu,
+create a node pool with the Ubuntu image type:
+
+.. code::
+
+    gcloud container node-pools create <node-pool-name> \
+        --cluster <cluster-name> \
+        --image-type UBUNTU_CONTAINERD \
+        --zone <zone> \
+        --num-nodes <number-of-nodes>
+
+
+Get cluster credentials
+-----------------------
+
+To interact with your cluster using ``kubectl``, fetch its credentials:
+
+.. code::
+
+    gcloud container clusters get-credentials <cluster-name> --zone <zone>
+
+
+Verify the node OS image
+------------------------
+
+Once the cluster is running, confirm that the nodes are using Ubuntu.
+
+Using ``kubectl``, check the ``OS-IMAGE`` column:
+
+.. code::
+
+    kubectl get nodes --output=wide
+
+.. code::
+
+    NAME                                            STATUS   ROLES    AGE   VERSION               INTERNAL-IP    EXTERNAL-IP    OS-IMAGE            KERNEL-VERSION    CONTAINER-RUNTIME
+    gke-ubuntu-cluster-default-pool-52e0bb17-4032   Ready    <none>   23m   v1.35.6-gke.1127000   x.x.x.x        x.x.x.x        Ubuntu 24.04.4 LTS  6.8.0-1055-gke    containerd://2.1.5
+    gke-ubuntu-cluster-default-pool-52e0bb17-vjw0   Ready    <none>   23m   v1.35.6-gke.1127000   x.x.x.x        x.x.x.x        Ubuntu 24.04.4 LTS  6.8.0-1055-gke    containerd://2.1.5
+    gke-ubuntu-cluster-default-pool-52e0bb17-vjxf   Ready    <none>   23m   v1.35.6-gke.1127000   x.x.x.x        x.x.x.x        Ubuntu 24.04.4 LTS  6.8.0-1055-gke    containerd://2.1.5
+
+Alternatively, inspect the image type of a node pool directly via ``gcloud``:
+
+.. code::
+
+    gcloud container node-pools describe <node-pool-name> \
+        --cluster <cluster-name> \
+        --zone <zone> \
+        --format="value(config.imageType)"
+
+The output should return ``UBUNTU_CONTAINERD``.
+
+You now have a GKE cluster running Ubuntu nodes, ready to deploy your containerized
+applications.
+
+
+.. _`Google Kubernetes Engine`: https://cloud.google.com/kubernetes-engine
+.. _`gcloud CLI tool`: https://docs.cloud.google.com/sdk/gcloud
+.. _`GKE documentation on creating clusters`: https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster

--- a/docs/google/google-how-to/gke/index.rst
+++ b/docs/google/google-how-to/gke/index.rst
@@ -5,8 +5,9 @@
 Using Kubernetes
 ================
 
-If you want to use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kubeflow on GKE, you can use these how-to guides.
+If you want to create a GKE cluster with Ubuntu nodes, use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kubeflow on GKE, you can use these how-to guides.
 
+* :doc:`Create a GKE cluster with Ubuntu nodes <create-gke-cluster-with-ubuntu-nodes>`
 * :doc:`Deploy Ubuntu Pro based k8s on GCE <deploy-kubernetes-with-ubuntu-pro>`
 * `Install Charmed Kubeflow on GKE`_
 
@@ -15,6 +16,7 @@ If you want to use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kub
    :hidden:
    :maxdepth: 1
    
+   create-gke-cluster-with-ubuntu-nodes
    deploy-kubernetes-with-ubuntu-pro
 
   

--- a/docs/google/google-how-to/index.rst
+++ b/docs/google/google-how-to/index.rst
@@ -25,8 +25,9 @@ While using Ubuntu on GCP, you'll need to perform tasks such as finding the righ
 GKE and Kubernetes
 ------------------
 
-If you want to use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kubeflow on GKE, you can use these instructions.
+If you want to create a GKE cluster with Ubuntu nodes, use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kubeflow on GKE, you can use these instructions.
 
+* :doc:`Create a GKE cluster with Ubuntu nodes <gke/create-gke-cluster-with-ubuntu-nodes>`
 * :doc:`Deploy Ubuntu Pro based k8s on GCE <gke/deploy-kubernetes-with-ubuntu-pro>`
 * `Install Charmed Kubeflow on GKE`_
 

--- a/docs/google/index.rst
+++ b/docs/google/index.rst
@@ -38,7 +38,7 @@ In this documentation
       - :doc:`Build a Pro golden image <google-how-to/gce/build-ubuntu-pro-golden-image>`
             
     * - **Custom deployments**
-      - :doc:`Deploy Kubernetes with Ubuntu Pro on GCE <google-how-to/gke/deploy-kubernetes-with-ubuntu-pro>` • :doc:`Create customized docker containers <google-how-to/gce/create-customized-docker-container>` • :doc:`Set hostname <google-how-to/gce/set-hostname-using-cloudinit>` 
+      - :doc:`Create a GKE cluster with Ubuntu nodes <google-how-to/gke/create-gke-cluster-with-ubuntu-nodes>` • :doc:`Deploy Kubernetes with Ubuntu Pro on GCE <google-how-to/gke/deploy-kubernetes-with-ubuntu-pro>` • :doc:`Create customized docker containers <google-how-to/gce/create-customized-docker-container>` • :doc:`Set hostname <google-how-to/gce/set-hostname-using-cloudinit>` 
       
     * - **Quality and policies**
       - :doc:`Security aspects <google-explanation/security-overview>` • :doc:`Image testing <google-explanation/gce-image-testing>` • :doc:`Image retention policy <google-explanation/gce-image-retention-policy>`


### PR DESCRIPTION
Add a new how-to guide covering how to create a Standard GKE cluster with Ubuntu (ubuntu_containerd) nodes using the gcloud CLI, including node pool configuration, credential setup, and OS image verification.