### PR TITLE
Replace :doc: references with :ref:

### DIFF
--- a/docs/all-clouds/all-clouds-explanation/architecture-variants.rst
+++ b/docs/all-clouds/all-clouds-explanation/architecture-variants.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Ubuntu cloud image architecture variants, starting with amd64v3 in Ubuntu 26.04, including supported variants, compatibility, and future plans.
 
+.. _architecture-variants:
+
 Architecture Variants Support in Ubuntu Cloud Images
 ====================================================
 

--- a/docs/all-clouds/all-clouds-explanation/cloud-init-metapackages.rst
+++ b/docs/all-clouds/all-clouds-explanation/cloud-init-metapackages.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Explore cloud-init metapackages in Ubuntu 25.04+, including cloud-specific dependencies and how to choose the right cloud-init package for your image.
 
+.. _cloud-init-metapackages:
+
 Cloud-init metapackages
 =======================
 

--- a/docs/all-clouds/all-clouds-explanation/confidential-computing.rst
+++ b/docs/all-clouds/all-clouds-explanation/confidential-computing.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how confidential computing protects sensitive workloads in Ubuntu cloud environments using trusted execution environments (Intel TDX and AMD SEV-SNP).
 
+.. _confidential-computing:
+
 Confidential computing
 ======================
 

--- a/docs/all-clouds/all-clouds-explanation/index.rst
+++ b/docs/all-clouds/all-clouds-explanation/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand key concepts for Ubuntu public cloud images, including release types, security, base images, and confidential computing.
 
+.. _all-clouds-explanation-index:
+
 Explanation
 ===========
 
@@ -11,9 +13,9 @@ Ubuntu image specifics
 
 Understand some of the fundamental variants of Ubuntu cloud images - different release types, base vs minimal images, and architecture variants.
 
-* :doc:`Cloud image release types <release-types>` 
-* :doc:`Ubuntu base and minimal images <ubuntu-base-and-minimal-images>` 
-* :doc:`Architecture variants support <architecture-variants>`
+* :ref:`Cloud image release types <release-types>` 
+* :ref:`Ubuntu base and minimal images <ubuntu-base-and-minimal-images>` 
+* :ref:`Architecture variants support <architecture-variants>`
 
 
 Security aspects
@@ -21,7 +23,7 @@ Security aspects
 
 Learn about the security practices and features built into Ubuntu cloud images. They include things like CVE handling, Kernel Livepatch, Hardening (DISA STIG, CIS), FIPS, AppArmor, and more.
 
-* :doc:`Security in Ubuntu cloud images <security-overview>`
+* :ref:`Security in Ubuntu cloud images <security-overview>`
 
 
 Customizations
@@ -29,8 +31,8 @@ Customizations
 
 Some specific customizations available in our cloud images are described here - confidential computing using trusted execution environments (Intel TDX and AMD SEV-SNP) and cloud-init metapackages.
 
-* :doc:`Confidential computing <confidential-computing>` 
-* :doc:`Cloud-init metapackages <cloud-init-metapackages>` 
+* :ref:`Confidential computing <confidential-computing>` 
+* :ref:`Cloud-init metapackages <cloud-init-metapackages>` 
 
 
 .. toctree::

--- a/docs/all-clouds/all-clouds-explanation/release-types.rst
+++ b/docs/all-clouds/all-clouds-explanation/release-types.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover the differences between Ubuntu cloud image release and daily types, and learn when to use each for your cloud deployments.
 
+.. _release-types:
+
 Cloud image release types
 =========================
 

--- a/docs/all-clouds/all-clouds-explanation/security-overview.rst
+++ b/docs/all-clouds/all-clouds-explanation/security-overview.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Ubuntu cloud image security, including CVE handling, hardening, FIPS, AppArmor, verified boot, and confidential computing features.
 
+.. _security-overview:
+
 Security in the Ubuntu cloud images
 ===================================
 

--- a/docs/all-clouds/all-clouds-explanation/ubuntu-base-and-minimal-images.rst
+++ b/docs/all-clouds/all-clouds-explanation/ubuntu-base-and-minimal-images.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Ubuntu base and minimal cloud images, their differences, and about the 'unminimize' command.
 
+.. _ubuntu-base-and-minimal-images:
+
 Ubuntu base and minimal images
 ==============================
 

--- a/docs/all-clouds/all-clouds-how-to/check-cve-on-instance.rst
+++ b/docs/all-clouds/all-clouds-how-to/check-cve-on-instance.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to check if your Ubuntu cloud instance is protected against specific CVEs using OVAL and OpenSCAP tools.
 
+.. _check-cve-on-instance:
+
 How to know if the Ubuntu image you have launched has addressed a specific CVE?
 ===============================================================================
 

--- a/docs/all-clouds/all-clouds-how-to/contribute-to-these-docs.rst
+++ b/docs/all-clouds/all-clouds-how-to/contribute-to-these-docs.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Find out how to contribute to Ubuntu cloud documentation, including editing, building, and submitting pull requests.
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/all-clouds/all-clouds-how-to/index.rst
+++ b/docs/all-clouds/all-clouds-how-to/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Step-by-step guides for common Ubuntu public cloud image operations, including CVE checks and NVIDIA driver installation.
 
+.. _all-clouds-how-to-index:
+
 How-to guides
 =============
 
@@ -11,21 +13,21 @@ Security-related
 
 A guide to help you check the CVE status of your Ubuntu image.
 
-* :doc:`Check CVE status of an image <check-cve-on-instance>`
+* :ref:`Check CVE status of an image <check-cve-on-instance>`
 
 Testing-related
 ----------------
 
 A guide to help you install NVIDIA drivers from the 'proposed' pocket for testing purposes.
 
-* :doc:`Install NVIDIA drivers from 'proposed' pocket for testing <install-proposed-nvidia-drivers-for-testing>`
+* :ref:`Install NVIDIA drivers from 'proposed' pocket for testing <install-proposed-nvidia-drivers-for-testing>`
 
 Ubuntu image specifics
 ----------------------
 
 A guide to help you migrate to a different kernel variant.
 
-* :doc:`Migrate kernel variants <migrate-kernel-variants>`
+* :ref:`Migrate kernel variants <migrate-kernel-variants>`
 
 .. toctree::
    :hidden:

--- a/docs/all-clouds/all-clouds-how-to/install-proposed-nvidia-drivers-for-testing.rst
+++ b/docs/all-clouds/all-clouds-how-to/install-proposed-nvidia-drivers-for-testing.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to install and test NVIDIA drivers from the proposed pocket on Ubuntu cloud images before official release, with step-by-step instructions.
 
+.. _install-proposed-nvidia-drivers-for-testing:
+
 Install NVIDIA drivers from proposed pocket for testing
 =======================================================
 This guide will help you test your workload on NVIDIA drivers available in proposed pocket before they are released.

--- a/docs/all-clouds/index.rst
+++ b/docs/all-clouds/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Ubuntu on public cloud platforms, including AWS, Azure, Google, IBM, Oracle, and optimized cloud images for enterprise workloads.
 
+.. _index:
+
 Ubuntu on public cloud
 ======================
 
@@ -27,12 +29,12 @@ For further details, refer to the cloud-specific documentation:
 ..  grid:: 1 1 2 2
    :padding: 0
 
-   .. grid-item-card:: :doc:`Ubuntu on AWS <aws:index>`   
-   .. grid-item-card:: :doc:`Ubuntu on Azure <azure:index>`  
-   .. grid-item-card:: :doc:`Ubuntu on GCP <google:index>` 
-   .. grid-item-card:: :doc:`Ubuntu on IBM <ibm:index>`
-   .. grid-item-card:: :doc:`Ubuntu on Oracle <oracle:index>`
-   .. grid-item-card:: :doc:`Ubuntu on VMware <vmware:index>`
+   .. grid-item-card:: :ref:`Ubuntu on AWS <aws:index>`   
+   .. grid-item-card:: :ref:`Ubuntu on Azure <azure:index>`  
+   .. grid-item-card:: :ref:`Ubuntu on GCP <google:index>` 
+   .. grid-item-card:: :ref:`Ubuntu on IBM <ibm:index>`
+   .. grid-item-card:: :ref:`Ubuntu on Oracle <oracle:index>`
+   .. grid-item-card:: :ref:`Ubuntu on VMware <vmware:index>`
 
 -----------------------------------------------------------------
 
@@ -46,8 +48,8 @@ Apart from the specific public clouds, Canonical also produces a variety of Ubun
 ..  grid:: 1 1 2 2
    :padding: 0
 
-   .. grid-item-card:: :doc:`Ubuntu on OCI container registries <oci:index>`
-   .. grid-item-card:: :doc:`Ubuntu Public Images <public-images:index>`
+   .. grid-item-card:: :ref:`Ubuntu on OCI container registries <oci:index>`
+   .. grid-item-card:: :ref:`Ubuntu Public Images <public-images:index>`
 
 
 
@@ -77,18 +79,18 @@ In this documentation
     :header-rows: 0
 
     * - **Ubuntu image specifics**
-      - :doc:`Base and minimal images <all-clouds-explanation/ubuntu-base-and-minimal-images>` •
-        :doc:`Architecture variants support <all-clouds-explanation/architecture-variants>` •
-        :doc:`Cloud image release types <all-clouds-explanation/release-types>` 
+      - :ref:`Base and minimal images <ubuntu-base-and-minimal-images>` •
+        :ref:`Architecture variants support <architecture-variants>` •
+        :ref:`Cloud image release types <release-types>` 
 
     * - **Security aspects**
-      - :doc:`Security in Ubuntu cloud images <all-clouds-explanation/security-overview>` •
-        :doc:`Check CVE status <all-clouds-how-to/check-cve-on-instance>` 
+      - :ref:`Security in Ubuntu cloud images <security-overview>` •
+        :ref:`Check CVE status <check-cve-on-instance>` 
         
     * - **Customizations**
-      - :doc:`Install NVIDIA drivers from proposed pocket <all-clouds-how-to/install-proposed-nvidia-drivers-for-testing>` •
-        :doc:`Confidential computing <all-clouds-explanation/confidential-computing>` •
-        :doc:`Cloud-init metapackages <all-clouds-explanation/cloud-init-metapackages>` 
+      - :ref:`Install NVIDIA drivers from proposed pocket <install-proposed-nvidia-drivers-for-testing>` •
+        :ref:`Confidential computing <confidential-computing>` •
+        :ref:`Cloud-init metapackages <cloud-init-metapackages>` 
     
 
 -----------------------------------------------------------------
@@ -99,9 +101,9 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides <all-clouds-how-to/index>` assume you have basic familiarity with Ubuntu cloud images and want to achieve specific goals. They are instructions applicable to applicable to any Ubuntu cloud image, regardless of the cloud platform. 
+* :ref:`How-to guides <all-clouds-how-to-index>` assume you have basic familiarity with Ubuntu cloud images and want to achieve specific goals. They are instructions applicable to applicable to any Ubuntu cloud image, regardless of the cloud platform. 
 
-* :doc:`Explanation <all-clouds-explanation/index>` includes topic overviews, background and context and detailed discussion. These are also applicable across all public cloud platforms.
+* :ref:`Explanation <all-clouds-explanation-index>` includes topic overviews, background and context and detailed discussion. These are also applicable across all public cloud platforms.
 
 -----------------------------------------------------------------
 
@@ -118,7 +120,7 @@ Get involved
 * `Join our online chat`_
 * `Discuss on Matrix`_
 * `Start using Ubuntu today`_
-* :doc:`all-clouds-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 Governance and policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/aws/aws-explanation/aws-image-testing.rst
+++ b/docs/aws/aws-explanation/aws-image-testing.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand how Canonical tests Ubuntu AWS images before release, using its own internal test suite covering EC2, hibernation and EKS worker images.
 
+.. _aws-image-testing:
+
 Image testing
 =============
 
@@ -12,7 +14,7 @@ We run **Canonical's own internal test suite** on each daily EC2 image. This sui
 Testing in the image life-cycle
 -------------------------------
 
-Ubuntu images on AWS move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :doc:`image release types <all-clouds:all-clouds-explanation/release-types>` and the :doc:`EC2 image retention policy <ec2-image-retention-policy>`.)
+Ubuntu images on AWS move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :ref:`image release types <all-clouds:release-types>` and the :ref:`EC2 image retention policy <ec2-image-retention-policy>`.)
 
 New images are built daily from the latest packages. Each daily build is uploaded and then exercised by the tests described below.
 
@@ -62,7 +64,7 @@ Image families and architectures
 
 The image families published for AWS (including standard, minimal, Ubuntu Pro and EKS worker images) are each tested with the checks relevant to them. Tests run across the supported architectures (`amd64` and `arm64`), so both architectures of an image are validated before release.
 
-Coverage is tailored per family: for example, EKS worker images additionally run a full Kubernetes conformance suite against a live cluster. For more on the available families, see :doc:`Canonical's offerings on AWS <canonical-offerings>`.
+Coverage is tailored per family: for example, EKS worker images additionally run a full Kubernetes conformance suite against a live cluster. For more on the available families, see :ref:`Canonical's offerings on AWS <canonical-offerings>`.
 
 
 Test outcomes
@@ -70,4 +72,4 @@ Test outcomes
 
 Test outcomes determine whether a daily image can be promoted: if all tests pass, the build becomes eligible for promotion to a release image; if any test fails, the build is not promoted.
 
-The result of this process is that the Ubuntu images you launch from AWS have each passed Canonical's own internal test suite for their family and architecture. For more on the security features validated along the way, see the :doc:`security overview <ubuntu-security-on-aws>`.
+The result of this process is that the Ubuntu images you launch from AWS have each passed Canonical's own internal test suite for their family and architecture. For more on the security features validated along the way, see the :ref:`security overview <ubuntu-security-on-aws>`.

--- a/docs/aws/aws-explanation/canonical-offerings.rst
+++ b/docs/aws/aws-explanation/canonical-offerings.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Canonical's Ubuntu image offerings on AWS, including Pro, minimal, EKS, and real-time kernel images for cloud workloads. Canonical's offerings in terms of appliances on AWS are also covered.
 
+.. _canonical-offerings:
+
 Canonical's offerings on AWS
 ============================
 
@@ -34,16 +36,16 @@ The different variations and the means to find them in AWS are summarized below:
      - **ARM64 (Graviton)** 
 
    * - Server 
-     - EC2 console, :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
-     - EC2 console, :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - EC2 console, :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - EC2 console, :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
    
    * - Server minimal
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+minimal&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+minimal&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+minimal&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+minimal&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
    
    * - Pro
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+pro&AMI_ARCHITECTURE=x86_64&CREATOR=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&filters=AMI_ARCHITECTURE%2CCREATOR>`__
-     - EC2 console, :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+pro&AMI_ARCHITECTURE=arm64&CREATOR=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&filters=AMI_ARCHITECTURE%2CCREATOR>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+pro&AMI_ARCHITECTURE=x86_64&CREATOR=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&filters=AMI_ARCHITECTURE%2CCREATOR>`__
+     - EC2 console, :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+pro&AMI_ARCHITECTURE=arm64&CREATOR=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&filters=AMI_ARCHITECTURE%2CCREATOR>`__
 
    * - Pro FIPS 
      - `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+pro+fips&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__, Private offers
@@ -54,12 +56,12 @@ The different variations and the means to find them in AWS are summarized below:
      - `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+pro+real&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
 
    * - EKS server images
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
 
    * - EKS Pro images
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+Pro+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
-     - :doc:`CLI<../aws-how-to/instances/find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+Pro+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+Pro+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=x86_64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
+     - :ref:`CLI <find-ubuntu-images>`, `Marketplace <https://aws.amazon.com/marketplace/search/results?searchTerms=Ubuntu+Pro+eks&CREATOR=565feec9-3d43-413e-9760-c651546613f2&AMI_ARCHITECTURE=arm64&filters=CREATOR%2CAMI_ARCHITECTURE>`__
 
 
 Optimizations for AWS

--- a/docs/aws/aws-explanation/ec2-image-retention-policy.rst
+++ b/docs/aws/aws-explanation/ec2-image-retention-policy.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand AWS Ubuntu image retention policy, including release, deprecation, and deletion stages for AMIs.
 
+.. _ec2-image-retention-policy:
+
 AWS image retention policy
 ==========================
 
@@ -20,7 +22,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`, and to get a list of these images on AWS, refer to: :doc:`../aws-how-to/instances/find-ubuntu-images`. In general, daily images are deleted, and release images are deprecated. Each image type is retained for a defined period, with a minimum number of recent images always preserved.
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`, and to get a list of these images on AWS, refer to: :ref:`find-ubuntu-images`. In general, daily images are deleted, and release images are deprecated. Each image type is retained for a defined period, with a minimum number of recent images always preserved.
 
 The retention policy can be summarized as follows:
 

--- a/docs/aws/aws-explanation/eks-snaps.rst
+++ b/docs/aws/aws-explanation/eks-snaps.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: See which snaps are bundled in Ubuntu EKS worker images on AWS and why, including kubelet, kubectl, and ECR credential provider.
 
+.. _eks-snaps:
+
 Snap usage in EKS worker images
 ===============================
 
@@ -17,7 +19,7 @@ Snaps
    * - **Snap Name**
      - **Provides**
      - **Bundled Since**
-   * - :doc:`kubelet-eks </aws-reference/eks-kubelet-snap>`
+   * - :ref:`kubelet-eks <eks-kubelet-snap>`
      - the `kubelet <https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/>`_ binary, which includes the primary configuration mechanism for kubelet
      - EKS 1.17
    * - kubectl-eks
@@ -27,4 +29,4 @@ Snaps
      - `aws-credential-provider <https://github.com/kubernetes/cloud-provider-aws/tree/master?tab=readme-ov-file#aws-credential-provider>`_, which provides credentials for allowing a k8s cluster to pull container images from ECR
      - EKS 1.28
 
-For deploying Ubuntu Pro containers on Kubernetes clusters, see :doc:`Deploy Ubuntu Pro containers on Kubernetes <oci:oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster>`.
+For deploying Ubuntu Pro containers on Kubernetes clusters, see :ref:`Deploy Ubuntu Pro containers on Kubernetes <oci:how-to-deploy-pro-container-on-pro-cluster>`.

--- a/docs/aws/aws-explanation/index.rst
+++ b/docs/aws/aws-explanation/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Explore Ubuntu on AWS: offerings, image retention, EKS snaps, and security features for cloud deployments.
 
+.. _aws-explanation-index:
+
 Explanation
 ===========
 
@@ -10,21 +12,21 @@ Our offerings on AWS
 --------------------
 Our offerings include customized Ubuntu images for different use cases, AWS-specific optimizations, and appliances for specific workloads.
 
-* :doc:`Canonical's offerings on AWS <canonical-offerings>`
+* :ref:`Canonical's offerings on AWS <canonical-offerings>`
 
 Snaps in EKS
 ------------
 A description of the snaps used in EKS worker images, and their purpose.
 
-* :doc:`Snap usage in EKS worker images <eks-snaps>`
+* :ref:`Snap usage in EKS worker images <eks-snaps>`
 
 Our policies
 ------------
 A description of the available security features, how our images are tested, and of our image retention policy.
 
-* :doc:`Security overview <ubuntu-security-on-aws>`
-* :doc:`Image testing <aws-image-testing>`
-* :doc:`Image retention policy <ec2-image-retention-policy>`
+* :ref:`Security overview <ubuntu-security-on-aws>`
+* :ref:`Image testing <aws-image-testing>`
+* :ref:`Image retention policy <ec2-image-retention-policy>`
 
 .. toctree::
    :hidden:

--- a/docs/aws/aws-explanation/ubuntu-security-on-aws.rst
+++ b/docs/aws/aws-explanation/ubuntu-security-on-aws.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about security features available with Ubuntu images on AWS, including Secure Boot, CIS hardening, and AMD SEV-SNP.
 
+.. _ubuntu-security-on-aws:
+
 Security features with Ubuntu on AWS
 ====================================
 
@@ -10,7 +12,7 @@ Ubuntu images on AWS include the security features provided by both Ubuntu and A
 Ubuntu security features
 ------------------------
 
-Ubuntu on AWS provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to Ubuntu server's `Introductory page on security`_.
+Ubuntu on AWS provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to Ubuntu server's `Introductory page on security`_.
 
 
 AWS security features
@@ -21,7 +23,7 @@ AWS offers comprehensive security and data protection in the cloud. `Security in
 Secure Boot and TPM
 ~~~~~~~~~~~~~~~~~~~
 
-AWS Secure Boot is a feature of Amazon EC2 instances, that allows only trusted software to be used during the booting process. To create and configure a secure boot image using an Ubuntu AMI, refer to :doc:`../aws-how-to/security/use-secureboot-and-vtpm`.
+AWS Secure Boot is a feature of Amazon EC2 instances, that allows only trusted software to be used during the booting process. To create and configure a secure boot image using an Ubuntu AMI, refer to :ref:`use-secureboot-and-vtpm`.
 
 CIS hardened image
 ~~~~~~~~~~~~~~~~~~
@@ -29,12 +31,12 @@ CIS hardened image
 CIS hardened images are available for use on Amazon EC2. These images include the security related configurations specified by the Center for Internet Security (CIS).
 
 To create a hardened image using Ubuntu Pro, refer to `Build a CIS hardened Ubuntu Pro server image on the AWS Console`_.
-For step-by-step hardening instructions, see :doc:`../aws-how-to/instances/cis-hardening`.
+For step-by-step hardening instructions, see :ref:`cis_post_deploy_hardening`.
 
 AMD SEV-SNP
 ~~~~~~~~~~~
 
-AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SEV-SNP) provides strong memory integrity protection to instances that use AMD EPYC processors. Details about launching AMD SEV-SNP instances are given in :doc:`../aws-how-to/instances/launch-and-attest-amd-sev-snp-instances`.
+AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SEV-SNP) provides strong memory integrity protection to instances that use AMD EPYC processors. Details about launching AMD SEV-SNP instances are given in :ref:`launch-and-attest-amd-sev-snp-instances`.
 
 Enhanced security using Ubuntu Pro
 ----------------------------------
@@ -45,7 +47,7 @@ Apart from the Ubuntu Server images, AWS also has images for `Ubuntu Pro`_, whic
 * Kernel Livepatch: These reduce downtime and unplanned reboots in case of kernel vulnerabilities.
 * FIPS compliance: Includes FIPS-certified modules to enable the use of Ubuntu in highly regulated environments.
 
-To find Ubuntu Pro images on AWS (for both EC2 and EKS), refer to :doc:`../aws-how-to/instances/find-ubuntu-images`. The product parameter allows you to specify Pro.
+To find Ubuntu Pro images on AWS (for both EC2 and EKS), refer to :ref:`find-ubuntu-images`. The product parameter allows you to specify Pro.
 
 
 .. _`Ubuntu security page`: https://ubuntu.com/security

--- a/docs/aws/aws-how-to/contribute-to-these-docs.rst
+++ b/docs/aws/aws-how-to/contribute-to-these-docs.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description:  Find out how to contribute to the Ubuntu on AWS documentation, including editing, building, and submitting pull requests.
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/aws/aws-how-to/index.rst
+++ b/docs/aws/aws-how-to/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: List of how-to guides that provide instructions for performing different operations related to Ubuntu on AWS.
 
+.. _aws-how-to-index:
+
 How-to guides
 =============
 
@@ -11,35 +13,35 @@ Ubuntu on EC2
 
 Perform tasks such as finding the right image to use and launching different types of instances including desktops, confidential computing instances, local VMs and hardened instances:
 
-* :doc:`Launch an instance using CLI <instances/launch-ubuntu-ec2-instance>`
-* :doc:`Find images <instances/find-ubuntu-images>`
-* :doc:`Launch a desktop <instances/launch-ubuntu-desktop>`
-* :doc:`Launch and attest an AMD SEV-SNP instance <instances/launch-and-attest-amd-sev-snp-instances>`
-* :doc:`Import a local Ubuntu VM into AWS <instances/import-local-vm-to-aws>`
-* :doc:`Complete hardening of a base CIS Level 1 instance <instances/cis-hardening>`
+* :ref:`Launch an instance using CLI <launch-ubuntu-ec2-instance>`
+* :ref:`Find images <find-ubuntu-images>`
+* :ref:`Launch a desktop <launch-ubuntu-desktop>`
+* :ref:`Launch and attest an AMD SEV-SNP instance <launch-and-attest-amd-sev-snp-instances>`
+* :ref:`Import a local Ubuntu VM into AWS <import-local-vm-to-aws>`
+* :ref:`Complete hardening of a base CIS Level 1 instance <cis_post_deploy_hardening>`
 
 Create a customized AMI and CloudFormation templates:
 
-* :doc:`Build an Ubuntu Pro AMI using Packer <instances/build-pro-ami-using-packer>`
-* :doc:`Build a custom Ubuntu Pro image with EC2 Image Builder <instances/build-ubuntu-pro-image-with-ec2-image-builder>`
-* :doc:`Create CloudFormation templates <instances/build-cloudformation-templates>`
+* :ref:`Build an Ubuntu Pro AMI using Packer <build-pro-ami-using-packer>`
+* :ref:`Build a custom Ubuntu Pro image with EC2 Image Builder <build-ubuntu-pro-image-with-ec2-image-builder>`
+* :ref:`Create CloudFormation templates <build-cloudformation-templates>`
 
 Perform custom configurations like installing custom kernels and drivers:
 
-* :doc:`Install 64k page kernel <instances/install-64k-kernel>`
-* :doc:`Install NVIDIA drivers <instances/install-nvidia-drivers>`
-* :doc:`Configure multiple NICs <instances/automatically-setup-multiple-nics>`
+* :ref:`Install 64k page kernel <install-64k-kernel>`
+* :ref:`Install NVIDIA drivers <install-nvidia-drivers>`
+* :ref:`Configure multiple NICs <automatically-setup-multiple-nics>`
 
 Perform upgrades and configure automated maintenance tasks:
 
-* :doc:`Perform in-place upgrade to Ubuntu Pro <instances/upgrade-in-place-from-lts-to-pro>`
-* :doc:`Upgrade Ubuntu LTS release <instances/upgrade-ubuntu-lts-release>`
-* :doc:`Upgrade to Ubuntu Pro at scale using tokens with SSM <instances/upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm>`
-* :doc:`Configure automated updates <instances/automatically-update-ubuntu-instances>`
+* :ref:`Perform in-place upgrade to Ubuntu Pro <upgrade-in-place-from-lts-to-pro>`
+* :ref:`Upgrade Ubuntu LTS release <upgrade-ubuntu-lts-release>`
+* :ref:`Upgrade to Ubuntu Pro at scale using tokens with SSM <upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm>`
+* :ref:`Configure automated updates <automatically-update-ubuntu-instances>`
 
 Use Canonical specific solutions:
  
-* :doc:`Deploy Canonical Data Science Stack <instances/data-science-stack-on-ec2>`
+* :ref:`Deploy Canonical Data Science Stack <data-science-stack-on-ec2>`
 
 
 Ubuntu on EKS
@@ -49,19 +51,19 @@ If you want to use Ubuntu, enable GPUs or install Kubeflow on Amazon's EKS servi
 
 Deployment options for using Ubuntu on EKS (using Ubuntu AMIs or Pro tokens):
 
-* :doc:`Deploy an Ubuntu EKS cluster <kubernetes/deploy-ubuntu-cluster-with-eks-ami>`
-* :doc:`Deploy an Ubuntu Pro EKS cluster <kubernetes/deploy-ubuntu-pro-cluster-with-eks-pro-ami>`
-* :doc:`Deploy an Ubuntu Pro FIPS EKS cluster <kubernetes/deploy-ubuntu-pro-fips-cluster>`
-* :doc:`Deploy a Pro cluster (with / without FIPS) using tokens <kubernetes/deploy-ubuntu-pro-cluster>`
+* :ref:`Deploy an Ubuntu EKS cluster <deploy-ubuntu-cluster-with-eks-ami>`
+* :ref:`Deploy an Ubuntu Pro EKS cluster <deploy-ubuntu-pro-cluster-with-eks-pro-ami>`
+* :ref:`Deploy an Ubuntu Pro FIPS EKS cluster <deploy-ubuntu-pro-fips-cluster>`
+* :ref:`Deploy a Pro cluster (with / without FIPS) using tokens <deploy-ubuntu-pro-cluster>`
 
 Deployment options for node groups:
 
-* :doc:`Deploy a self-managed Ubuntu node group <kubernetes/deploy-self-managed-node-group>`
-* :doc:`Deploy managed Ubuntu node groups <kubernetes/deploy-managed-node-group>`
+* :ref:`Deploy a self-managed Ubuntu node group <deploy-self-managed-node-group>`
+* :ref:`Deploy managed Ubuntu node groups <deploy-managed-node-group>`
 
 Custom EKS deployments:
 
-* :doc:`Enable GPUs on EKS worker nodes <kubernetes/enable-gpus-on-eks>`
+* :ref:`Enable GPUs on EKS worker nodes <enable-gpus-on-eks>`
 * `Install Kubeflow on EKS (external link)`_
 
 
@@ -70,7 +72,7 @@ Using security features
 
 AWS provides multiple features for additional security, many of which are supported through our Ubuntu images. This guide walks you through the steps needed to use these security features.
 
-* :doc:`Use Secure Boot and TPM <security/use-secureboot-and-vtpm>`
+* :ref:`Use Secure Boot and TPM <use-secureboot-and-vtpm>`
 
 
 .. toctree::

--- a/docs/aws/aws-how-to/instances/automatically-setup-multiple-nics.rst
+++ b/docs/aws/aws-how-to/instances/automatically-setup-multiple-nics.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to automatically configure multiple network interfaces on EC2. Includes steps for enabling configuration during instance creation and on running instances.
 
+.. _automatically-setup-multiple-nics:
+
 Automatically configure multiple NICs on EC2 instances
 ======================================================
 

--- a/docs/aws/aws-how-to/instances/automatically-update-ubuntu-instances.rst
+++ b/docs/aws/aws-how-to/instances/automatically-update-ubuntu-instances.rst
@@ -1,10 +1,12 @@
 .. meta::
    :description: Learn how to automate Ubuntu instance updates using AWS Systems Manager. Step-by-step guide for creating maintenance windows and registering run command tasks in SSM.
 
+.. _automatically-update-ubuntu-instances:
+
 Set up automated updates of Ubuntu instances using AWS SSM
 ==========================================================
 
-AWS Systems Manager (SSM) can be used to set up automated updates of your Ubuntu and :doc:`Ubuntu Pro <../../aws-reference/pro>` instances. This can be done by creating an automated maintenance window and registering an appropriate run command task for that window.
+AWS Systems Manager (SSM) can be used to set up automated updates of your Ubuntu and :ref:`Ubuntu Pro <pro>` instances. This can be done by creating an automated maintenance window and registering an appropriate run command task for that window.
 
 .. note::
 

--- a/docs/aws/aws-how-to/instances/build-cloudformation-templates.rst
+++ b/docs/aws/aws-how-to/instances/build-cloudformation-templates.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to create CloudFormation templates with latest Ubuntu AMIs. Step-by-step guide for querying SSM parameter store for latest AMI IDs, and creating CloudFormation templates.
 
+.. _build-cloudformation-templates:
+
 Create CloudFormation templates with the latest Ubuntu AMI
 ==========================================================
 
@@ -35,7 +37,7 @@ The Ubuntu version (e.g. noble, jammy) and the architecture (ARM64 or AMD64) can
             Properties:
                   ImageId: !Ref LatestAmiId
 
-For upgrading between Ubuntu LTS releases, see :doc:`upgrade-ubuntu-lts-release`.
+For upgrading between Ubuntu LTS releases, see :ref:`upgrade-ubuntu-lts-release`.
 
 
 Ubuntu Pro
@@ -61,7 +63,7 @@ The format for the parameter is:
 * VIRT_TYPE: `pv` or `hvm`
 * VOL_TYPE: `ebs-gp3` (for >=23.10), `ebs-gp2` (for <=23.04), `ebs-io1`, `ebs-standard`, or `instance-store`
 
-To upgrade an existing LTS instance to Ubuntu Pro, see :doc:`upgrade-in-place-from-lts-to-pro`.
+To upgrade an existing LTS instance to Ubuntu Pro, see :ref:`upgrade-in-place-from-lts-to-pro`.
 
 
 Ubuntu Pro FIPS
@@ -107,7 +109,7 @@ To create the parameter in your CloudFormation template, choose a product ID fro
 
    Before launching any Marketplace product you'll have to subscribe to it, even if it is free of charge.
 
-To deploy an Ubuntu Pro FIPS cluster on EKS, see :doc:`../kubernetes/deploy-ubuntu-pro-fips-cluster`.
+To deploy an Ubuntu Pro FIPS cluster on EKS, see :ref:`deploy-ubuntu-pro-fips-cluster`.
 
 
 Ubuntu LTS for EKS
@@ -121,7 +123,7 @@ For Ubuntu-EKS AMI IDs, use the following query string with any required changes
                 Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
                 Default: '/aws/service/canonical/ubuntu/eks/24.04/1.32/stable/current/amd64/hvm/ebs-gp3/ami-id'
 
-For deploying an Ubuntu EKS cluster, see :doc:`../kubernetes/deploy-ubuntu-cluster-with-eks-ami`. For Ubuntu Pro on EKS, see :doc:`../kubernetes/deploy-ubuntu-pro-cluster-with-eks-pro-ami`.
+For deploying an Ubuntu EKS cluster, see :ref:`deploy-ubuntu-cluster-with-eks-ami`. For Ubuntu Pro on EKS, see :ref:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`.
 
 
 Create template
@@ -184,7 +186,7 @@ A very basic CloudFormation template for Ubuntu LTS could look like:
 Further references
 ------------------
 
-* :doc:`find-ubuntu-images`
+* :ref:`find-ubuntu-images`
 * `AWS reference for SSM based querying of latest AMI IDs`_
 * `AWS reference for integrating CloudFormation with SSM parameter store`_
 

--- a/docs/aws/aws-how-to/instances/build-pro-ami-using-packer.rst
+++ b/docs/aws/aws-how-to/instances/build-pro-ami-using-packer.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to build custom Ubuntu Pro AMIs using Packer. Step-by-step guide with detailed instructions for setting up Packer, defining builders and provisioners, and creating a reusable golden image. 
 
+.. _build-pro-ami-using-packer:
+
 Build an Ubuntu Pro AMI using Packer
 ====================================
 
@@ -13,7 +15,7 @@ We'll be using Ubuntu Pro 24.04 LTS for this guide, but the method is equally ap
    * For **Ubuntu Pro FIPS**, it is better to use a pre-enabled FIPS image from the Marketplace to avoid unnecessary additional steps. 
    * For **Ubuntu LTS**, you can use this method with a small change as explained at the end of the :ref:`define-provisioners` section below. 
    * For **Ubuntu 22.04 LTS and above** you need Packer version 1.8.1 or newer.
-   * For an overview of Ubuntu image types, see :doc:`Ubuntu base and minimal images <all-clouds:all-clouds-explanation/ubuntu-base-and-minimal-images>`.
+   * For an overview of Ubuntu image types, see :ref:`Ubuntu base and minimal images <all-clouds:ubuntu-base-and-minimal-images>`.
 
 Basic setup
 -------------
@@ -50,7 +52,7 @@ Create AWS Credentials
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Follow the instructions in the *Programmatic access* section of the `IAM page for creating credentials`_. For a list of the minimal set of permissions needed in your IAM user or role policy, refer to `IAM permissions needed for Packer`_.
-For an overview of AWS credentials used with EC2, see :doc:`../../aws-reference/ec2-credentials`.
+For an overview of AWS credentials used with EC2, see :ref:`ec2-credentials`.
 
 Save your credentials, they should be similar to:
 

--- a/docs/aws/aws-how-to/instances/build-ubuntu-pro-image-with-ec2-image-builder.rst
+++ b/docs/aws/aws-how-to/instances/build-ubuntu-pro-image-with-ec2-image-builder.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to build custom Ubuntu Pro images using EC2 Image Builder with the Ubuntu Pro component from the AWS Marketplace. Bake Pro services and security features directly into your AMIs at build time.
 
+.. _build-ubuntu-pro-image-with-ec2-image-builder:
+
 Build a custom Ubuntu Pro image with EC2 Image Builder
 =======================================================
 

--- a/docs/aws/aws-how-to/instances/cis-hardening.rst
+++ b/docs/aws/aws-how-to/instances/cis-hardening.rst
@@ -348,7 +348,7 @@ If passwords are enabled, follow the instructions in the
 CIS 5.1.1 - Ensure permissions on /etc/ssh/sshd_config are configured
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The USG remediation sets permissions on ``/etc/ssh/sshd_config`` itself but leaves files
-inside ``/etc/ssh/sshd_config.d/`` unchanged. Files added by :doc:`cloud-init <public-images:public-images-how-to/use-local-cloud-init-ds>` or other tooling
+inside ``/etc/ssh/sshd_config.d/`` unchanged. Files added by :ref:`cloud-init <public-images:use-local-cloud-init-ds>` or other tooling
 after remediation may not have ``0600`` permissions. Check and correct manually if needed::
 
    sudo chmod 0600 /etc/ssh/sshd_config.d/*

--- a/docs/aws/aws-how-to/instances/data-science-stack-on-ec2.rst
+++ b/docs/aws/aws-how-to/instances/data-science-stack-on-ec2.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy Canonical Data Science Stack on a GPU-enabled EC2 instance. Step-by-step guide for launching a G4DN instance, installing GPU drivers, setting up MicroK8s, and creating Jupyter Notebooks with CUDA support. 
 
 
+.. _data-science-stack-on-ec2:
+
 Deploy Canonical Data Science Stack on EC2 using a GPU-enabled instance type
 ============================================================================
 
@@ -45,7 +47,7 @@ Once you have connected, run a full upgrade:
 If you get a new kernel, it is advised to restart the machine before proceeding.
 
 Now install the GPU drivers:
-For comprehensive GPU driver installation instructions, see :doc:`install-nvidia-drivers`.
+For comprehensive GPU driver installation instructions, see :ref:`install-nvidia-drivers`.
 
 
 .. code::

--- a/docs/aws/aws-how-to/instances/find-ubuntu-images.rst
+++ b/docs/aws/aws-how-to/instances/find-ubuntu-images.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to find and select Ubuntu AMIs for EC2 and EKS. Includes methods using SSM Parameter Store, describe-images API, and AWS Console, with tips for verifying ownership and using Marketplace images.
 
+.. _find-ubuntu-images:
+
 Find Ubuntu images on AWS
 =========================
 

--- a/docs/aws/aws-how-to/instances/import-local-vm-to-aws.rst
+++ b/docs/aws/aws-how-to/instances/import-local-vm-to-aws.rst
@@ -2,6 +2,8 @@
    :description: Learn how to import local virtual machines to AWS EC2. Step-by-step guide for uploading VM images to S3, creating IAM roles, importing VMs, and preparing them for production on AWS.
 
 
+.. _import-local-vm-to-aws:
+
 Import a local Ubuntu VM into AWS
 ==================================
 
@@ -20,7 +22,7 @@ Requirements
         
         ``sudo qemu-img convert -O raw /var/lib/libvirt/images/my-machine.qcow2 my-machine.raw``
     
-        For more about LXD and OpenStack Ubuntu images, see :doc:`LXD/OpenStack images <public-images:public-images-explanation/lxd-openstack-images>`.
+        For more about LXD and OpenStack Ubuntu images, see :ref:`LXD/OpenStack images <public-images:lxd-openstack-images>`.
 
 
 Upload your OVA machine image to S3
@@ -124,7 +126,7 @@ Get the VM image ready for production
 -------------------------------------
 
 The VM image is almost ready to be used at scale on AWS. The last step is to allow cloud-init to reinitialize the machine ID. This ensures that each instance launched from this image will generate its own machine ID and will re-detect the cloud that it is running on so that certain features specific to AWS can be enabled. This is also needed if you’re planning to upgrade to Ubuntu Pro in the future.
-For using cloud-init with a local data source, see :doc:`Use a local cloud-init data source <public-images:public-images-how-to/use-local-cloud-init-ds>`.
+For using cloud-init with a local data source, see :ref:`Use a local cloud-init data source <public-images:use-local-cloud-init-ds>`.
 
 Run:
 

--- a/docs/aws/aws-how-to/instances/index.rst
+++ b/docs/aws/aws-how-to/instances/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: List of how-to guides related to launching and using Ubuntu-based EC2 instances.
 
+.. _instances-index:
+
 Using EC2
 =========
 
@@ -9,48 +11,48 @@ These how-to guides relate to launching and using Ubuntu-based EC2 instances. Th
 Finding images and launching instances
 --------------------------------------
 
-Guides to help you find the right Ubuntu image for your use case and launch different types of EC2 instances, including desktops, :doc:`confidential computing <all-clouds:all-clouds-explanation/confidential-computing>` instances, local VMs and hardened instances.
+Guides to help you find the right Ubuntu image for your use case and launch different types of EC2 instances, including desktops, :ref:`confidential computing <all-clouds:confidential-computing>` instances, local VMs and hardened instances.
 
-* :doc:`Launch an instance using CLI <launch-ubuntu-ec2-instance>`
-* :doc:`Find images <find-ubuntu-images>`
-* :doc:`Launch a desktop <launch-ubuntu-desktop>`
-* :doc:`Launch and attest an AMD SEV-SNP instance <launch-and-attest-amd-sev-snp-instances>`
-* :doc:`Import a local Ubuntu VM into AWS <import-local-vm-to-aws>`
-* :doc:`Complete hardening of a base CIS Level 1 instance <cis-hardening>`
+* :ref:`Launch an instance using CLI <launch-ubuntu-ec2-instance>`
+* :ref:`Find images <find-ubuntu-images>`
+* :ref:`Launch a desktop <launch-ubuntu-desktop>`
+* :ref:`Launch and attest an AMD SEV-SNP instance <launch-and-attest-amd-sev-snp-instances>`
+* :ref:`Import a local Ubuntu VM into AWS <import-local-vm-to-aws>`
+* :ref:`Complete hardening of a base CIS Level 1 instance <cis_post_deploy_hardening>`
 
 Creating AMIs and CloudFormation templates
 ------------------------------------------
 
 Guides to help you create custom AMIs and CloudFormation templates using Ubuntu images.
 
-* :doc:`Build an Ubuntu Pro AMI using Packer <build-pro-ami-using-packer>`
-* :doc:`Create CloudFormation templates <build-cloudformation-templates>`
+* :ref:`Build an Ubuntu Pro AMI using Packer <build-pro-ami-using-packer>`
+* :ref:`Create CloudFormation templates <build-cloudformation-templates>`
 
 Custom configurations
 ---------------------
 
 Guides to help you install custom kernels and drivers and configure network cards on your EC2 instances.
 
-* :doc:`Install 64k page kernel <install-64k-kernel>`
-* :doc:`Install NVIDIA drivers <install-nvidia-drivers>`
-* :doc:`Configure multiple NICs <automatically-setup-multiple-nics>`
+* :ref:`Install 64k page kernel <install-64k-kernel>`
+* :ref:`Install NVIDIA drivers <install-nvidia-drivers>`
+* :ref:`Configure multiple NICs <automatically-setup-multiple-nics>`
 
 Upgrades and maintenance
 ------------------------
 
 Guides to help you perform upgrades and automate them on your EC2 instances.
 
-* :doc:`Perform in-place upgrade to Ubuntu Pro <upgrade-in-place-from-lts-to-pro>`
-* :doc:`Upgrade Ubuntu LTS release <upgrade-ubuntu-lts-release>`
-* :doc:`Upgrade to Ubuntu Pro at scale using tokens with SSM <upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm>`
-* :doc:`Configure automated updates <automatically-update-ubuntu-instances>`
+* :ref:`Perform in-place upgrade to Ubuntu Pro <upgrade-in-place-from-lts-to-pro>`
+* :ref:`Upgrade Ubuntu LTS release <upgrade-ubuntu-lts-release>`
+* :ref:`Upgrade to Ubuntu Pro at scale using tokens with SSM <upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm>`
+* :ref:`Configure automated updates <automatically-update-ubuntu-instances>`
 
 Using Canonical Products
 ----------------------------
 
 Deploy Canonical products such as the data science stack on your EC2 instances.
 
-* :doc:`Deploy Canonical Data Science Stack <data-science-stack-on-ec2>`
+* :ref:`Deploy Canonical Data Science Stack <data-science-stack-on-ec2>`
 
 
 .. toctree::

--- a/docs/aws/aws-how-to/instances/install-64k-kernel.rst
+++ b/docs/aws/aws-how-to/instances/install-64k-kernel.rst
@@ -2,6 +2,8 @@
    :description: Learn how to install 64k page kernel on ARM64 EC2 instances. Includes steps for switching to the 64k page kernel and selecting the kernel flavor permanently.
 
 
+.. _install-64k-kernel:
+
 Install 64k page kernel on ARM64 instances 
 ==========================================
 

--- a/docs/aws/aws-how-to/instances/install-nvidia-drivers.rst
+++ b/docs/aws/aws-how-to/instances/install-nvidia-drivers.rst
@@ -2,6 +2,8 @@
    :description: Learn how to install NVIDIA drivers on GPU-enabled EC2 instances. Launch a G4DN instance, install the NVIDIA driver and verify the installation with nvidia-smi.
 
 
+.. _install-nvidia-drivers:
+
 Install NVIDIA drivers on a GPU-enabled EC2 instance 
 =====================================================
 
@@ -10,14 +12,14 @@ AWS provides GPU-enabled instance types for workloads that require GPU compute p
 
 For more comprehensive instructions on checking the available drivers and installing the correct one based on different use-cases, refer to the `Ubuntu server documentation for installing NVIDIA drivers`_.
 
-To test proposed NVIDIA driver versions before release, see :doc:`all-clouds:all-clouds-how-to/install-proposed-nvidia-drivers-for-testing`.
+To test proposed NVIDIA driver versions before release, see :ref:`all-clouds:install-proposed-nvidia-drivers-for-testing`.
 
 Launch your instance
 --------------------
 
 Launch your Ubuntu 24.04 LTS VM using either `AWS CLI or the web console`_. Make sure you allocate enough disk space for your use case, as ML models tend to need a significant amount. 
 
-For detailed instructions on launching Ubuntu EC2 instances, see :doc:`launch-ubuntu-ec2-instance`.
+For detailed instructions on launching Ubuntu EC2 instances, see :ref:`launch-ubuntu-ec2-instance`.
 
 SSH access is required, so make sure to either open port 22 or enable SSM to access the machine through Session Manager. 
 
@@ -117,7 +119,7 @@ This should display the NVIDIA GPU information, including the CUDA version in th
 
 
 If CUDA was not installed, you can visit the `NVIDIA website`_ to download the CUDA version that matches the driver you just installed.
-For a complete ML environment including Jupyter and frameworks, see :doc:`data-science-stack-on-ec2`.
+For a complete ML environment including Jupyter and frameworks, see :ref:`data-science-stack-on-ec2`.
 
 
 

--- a/docs/aws/aws-how-to/instances/launch-and-attest-amd-sev-snp-instances.rst
+++ b/docs/aws/aws-how-to/instances/launch-and-attest-amd-sev-snp-instances.rst
@@ -1,10 +1,12 @@
 .. meta::
    :description: Learn how to launch and attest AMD SEV-SNP enabled instances on AWS. Includes steps for launching the instance, building the attestation tool, and validating the attestation report.  
 
+.. _launch-and-attest-amd-sev-snp-instances:
+
 Launch and attest AMD SEV-SNP instances with Ubuntu 24.04 on AWS
 ================================================================
 
-Amazon EC2 now supports AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SEV-SNP), on M6a, C6a, and R6a instance types in certain regions. These instances, when used with Ubuntu 24.04 LTS, allow customers to leverage AMD's confidential computing capabilities (:doc:`overview <all-clouds:all-clouds-explanation/confidential-computing>`) on AWS.
+Amazon EC2 now supports AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SEV-SNP), on M6a, C6a, and R6a instance types in certain regions. These instances, when used with Ubuntu 24.04 LTS, allow customers to leverage AMD's confidential computing capabilities (:ref:`overview <all-clouds:confidential-computing>`) on AWS.
 
 This guide covers the steps needed to launch, test and validate the AMD SEV-SNP capabilities on AWS. The steps have been tested with Ubuntu 24.04 LTS and Ubuntu Pro 24.04 LTS on us-east-2.
 

--- a/docs/aws/aws-how-to/instances/launch-ubuntu-desktop.rst
+++ b/docs/aws/aws-how-to/instances/launch-ubuntu-desktop.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to launch an Ubuntu Desktop on AWS EC2. Includes steps for launching the instance, installing the desktop environment, configuring RDP, and connecting to the instance.  
 
+.. _launch-ubuntu-desktop:
+
 Launch an Ubuntu desktop on EC2
 ===============================
 
@@ -41,7 +43,7 @@ Retrieve the latest AMI ID for an Ubuntu image using one of the following comman
     aws ssm get-parameters --names /aws/service/canonical/ubuntu/pro-server/26.04/stable/current/arm64/hvm/ebs-gp3/ami-id
 
 
-Now launch the instance by referring to the instructions for :doc:`launching using the AWS CLI<./launch-ubuntu-ec2-instance>`.
+Now launch the instance by referring to the instructions for :ref:`launching using the AWS CLI <launch-ubuntu-ec2-instance>`.
 
 
 Install Ubuntu desktop 

--- a/docs/aws/aws-how-to/instances/launch-ubuntu-ec2-instance.rst
+++ b/docs/aws/aws-how-to/instances/launch-ubuntu-ec2-instance.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to launch Ubuntu EC2 instances using AWS CLI. Step-by-step guide for setting up credentials, installing AWS CLI, finding Ubuntu AMIs, launching instances and connecting to them. 
 
+.. _launch-ubuntu-ec2-instance:
+
 Launch an Ubuntu EC2 instance using the AWS CLI
 ===============================================
 
@@ -15,7 +17,7 @@ Assuming you have an existing AWS account and some means for terminal based comm
 Setup credentials
 -----------------
 
-You need key pairs and access keys to use AWS and EC2 services. A brief introduction to these credentials can be found in :doc:`../../aws-reference/ec2-credentials`.
+You need key pairs and access keys to use AWS and EC2 services. A brief introduction to these credentials can be found in :ref:`ec2-credentials`.
 
 Create a key pair
 ~~~~~~~~~~~~~~~~~
@@ -65,7 +67,7 @@ Use the access key details saved earlier, specify a region and choose your prefe
 Find an Ubuntu AMI
 ------------------
 
-To launch an EC2 instance that uses Ubuntu, you'll need to choose an appropriate Ubuntu image and get the official AMI ID for it. The image can be chosen based on your requirements, e.g. the machine's architecture, features needed from the OS, etc. Once chosen, get the corresponding AMI ID by following the instructions at :doc:`./find-ubuntu-images`.
+To launch an EC2 instance that uses Ubuntu, you'll need to choose an appropriate Ubuntu image and get the official AMI ID for it. The image can be chosen based on your requirements, e.g. the machine's architecture, features needed from the OS, etc. Once chosen, get the corresponding AMI ID by following the instructions at :ref:`find-ubuntu-images`.
 
 .. note::
     

--- a/docs/aws/aws-how-to/instances/upgrade-in-place-from-lts-to-pro.rst
+++ b/docs/aws/aws-how-to/instances/upgrade-in-place-from-lts-to-pro.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to upgrade from Ubuntu LTS to Ubuntu Pro in-place. Step-by-step guide for using AWS License Manager to perform the upgrade, including requirements and verification steps.
 
+.. _upgrade-in-place-from-lts-to-pro:
+
 Upgrade from Ubuntu to Ubuntu Pro using AWS License Manager
 ===========================================================
 

--- a/docs/aws/aws-how-to/instances/upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm.rst
+++ b/docs/aws/aws-how-to/instances/upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm.rst
@@ -2,6 +2,8 @@
    :description: Learn how to upgrade to Ubuntu Pro at scale using AWS SSM. Step-by-step guide for creating SSM documents to attach Ubuntu Pro tokens and applying updates on multiple instances simultaneously. 
 
 
+.. _upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm:
+
 Upgrade to Ubuntu Pro at scale using tokens with SSM
 ====================================================
 

--- a/docs/aws/aws-how-to/instances/upgrade-ubuntu-lts-release.rst
+++ b/docs/aws/aws-how-to/instances/upgrade-ubuntu-lts-release.rst
@@ -2,6 +2,8 @@
    :description: Learn how to upgrade Ubuntu LTS releases on EC2. Includes manual intervention steps and best practices to ensure a smooth upgrade process.
 
 
+.. _upgrade-ubuntu-lts-release:
+
 Upgrade Ubuntu LTS release on EC2
 ==================================
 

--- a/docs/aws/aws-how-to/kubernetes/deploy-managed-node-group.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-managed-node-group.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to deploy EKS managed node groups with Ubuntu. Includes steps for creating a custom image, a corresponding launch template and finally a managed node group.
 
+.. _deploy-managed-node-group:
+
 Deploy managed Ubuntu nodes on EKS
 ==================================
 

--- a/docs/aws/aws-how-to/kubernetes/deploy-self-managed-node-group.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-self-managed-node-group.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy self-managed node groups using Ubuntu nodes on EKS. Specify 'Ubuntu' as the node AMI family when creating a node group with eksctl.
 
 
+.. _deploy-self-managed-node-group:
+
 Deploy self-managed Ubuntu nodes
 ================================
 
@@ -52,7 +54,7 @@ with one of the following supported Node AMI families:
 
 .. note::
    If you prefer to use managed node groups, refer to
-   :doc:`this guide <deploy-managed-node-group>`. In that scenario, the AMI is
+   :ref:`this guide <deploy-managed-node-group>`. In that scenario, the AMI is
    defined via a launch template, and EKS automatically handles the node
    recycling strategy.
 

--- a/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-cluster-with-eks-ami.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-cluster-with-eks-ami.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy Ubuntu EKS clusters using eksctl and the official EKS AMIs. 
 
 
+.. _deploy-ubuntu-cluster-with-eks-ami:
+
 Deploy an Ubuntu EKS cluster
 ============================
 

--- a/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-cluster-with-eks-pro-ami.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-cluster-with-eks-pro-ami.rst
@@ -1,14 +1,16 @@
 .. meta::
    :description: Learn how to deploy Ubuntu Pro EKS clusters using an EKS Pro AMI. Includes steps for creating an eksctl config file and using it to deploy the cluster.
 
+.. _deploy-ubuntu-pro-cluster-with-eks-pro-ami:
+
 Deploy an Ubuntu Pro EKS cluster - using a Pro AMI
 ==================================================
 
 This guide shows how to deploy an Ubuntu Pro EKS cluster using an EKS Pro AMI. 
 
-An EKS Pro AMI is an :doc:`Ubuntu EKS AMI <./deploy-ubuntu-cluster-with-eks-ami>` that includes the `Pro subscription`_, which provides services such as Livepatch for LTS-based nodes and Expanded Security Maintenance (ESM). It also grants the cluster a license to run Pro containers with no limitations on quantity or variety.
+An EKS Pro AMI is an :ref:`Ubuntu EKS AMI <deploy-ubuntu-cluster-with-eks-ami>` that includes the `Pro subscription`_, which provides services such as Livepatch for LTS-based nodes and Expanded Security Maintenance (ESM). It also grants the cluster a license to run Pro containers with no limitations on quantity or variety.
 
-Ubuntu Pro 22.04 LTS supports EKS up to version 1.34, while Ubuntu 24.04 LTS will continue supporting current and future EKS versions. Currently, only 22.04 LTS provides NIST-validated FIPS components. For earlier versions or other combinations of EKS and Ubuntu releases, use Pro tokens as described in :doc:`./deploy-ubuntu-pro-cluster`. To include FIPS, refer to :doc:`./deploy-ubuntu-pro-fips-cluster`.
+Ubuntu Pro 22.04 LTS supports EKS up to version 1.34, while Ubuntu 24.04 LTS will continue supporting current and future EKS versions. Currently, only 22.04 LTS provides NIST-validated FIPS components. For earlier versions or other combinations of EKS and Ubuntu releases, use Pro tokens as described in :ref:`deploy-ubuntu-pro-cluster`. To include FIPS, refer to :ref:`deploy-ubuntu-pro-fips-cluster`.
 
 Prerequisites
 -------------

--- a/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-cluster.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-cluster.rst
@@ -1,23 +1,25 @@
 .. meta::
    :description: Learn how to deploy an EKS cluster with Ubuntu Pro nodes using Ubuntu Pro tokens and EC2 launch templates.
 
+.. _deploy-ubuntu-pro-cluster:
+
 Deploy an Ubuntu Pro EKS cluster — using Pro tokens
 ===================================================
 
 This guide shows how to deploy an EKS cluster with Ubuntu Pro nodes using Ubuntu Pro tokens and EC2 launch templates.
 
-This guide covers creating Pro clusters using tokens only. If you prefer getting a pre-activated Ubuntu Pro AMI with metered billing, please check :doc:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`.
+This guide covers creating Pro clusters using tokens only. If you prefer getting a pre-activated Ubuntu Pro AMI with metered billing, please check :ref:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`.
 
 For FIPS clusters, please note that only Ubuntu 22.04 LTS has NIST-validated FIPS modules at the moment.
 
-For a dedicated FIPS guide, see :doc:`deploy-ubuntu-pro-fips-cluster`.
+For a dedicated FIPS guide, see :ref:`deploy-ubuntu-pro-fips-cluster`.
 
 Prerequisites
 ~~~~~~~~~~~~~
 
 - ``eksctl``: Check the instructions to `install eksctl`_
 - ``Packer`` version 1.8.1 or newer installed. (`Packer installation instructions`_). Only needed if you want to enable FIPS for the cluster nodes. 
-- Your AWS access key ID and secret access key (see :doc:`../../aws-reference/ec2-credentials`)
+- Your AWS access key ID and secret access key (see :ref:`ec2-credentials`)
 - An Ubuntu Pro token
 
 
@@ -161,7 +163,7 @@ The steps needed for deploying the cluster depend on whether you need to enable 
         .. note::
             Save a copy of the provided AMI ID for the next step.
 
-        See also: :doc:`Build a Pro AMI using Packer <../instances/build-pro-ami-using-packer>`.
+        See also: :ref:`Build a Pro AMI using Packer <build-pro-ami-using-packer>`.
 
 
 Create the ``eksctl`` config file
@@ -182,7 +184,7 @@ To do so, start by creating a ``cluster.yaml`` with the following content
 
 Change <CLUSTER_NAME> and <YOUR_EKS_VERSION> accordingly. 
 
-Note that Ubuntu 22.04 LTS (non pro) covers EKS versions up to 1.32. For newer EKS versions please use Ubuntu 24.04 LTS or use the already pre activated Pro AMIs which provide broader coverage: :doc:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`).
+Note that Ubuntu 22.04 LTS (non pro) covers EKS versions up to 1.32. For newer EKS versions please use Ubuntu 24.04 LTS or use the already pre activated Pro AMIs which provide broader coverage: :ref:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`).
 
 Add the following content to your file.
 

--- a/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-fips-cluster.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-fips-cluster.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy an EKS cluster of FIPS-certified Ubuntu nodes. Includes creating your custom EKS FIPS AMI using Packer, and then deploying it using eksctl.
 
 
+.. _deploy-ubuntu-pro-fips-cluster:
+
 Deploy an Ubuntu Pro FIPS EKS cluster - using a Pro AMI
 =======================================================
 
@@ -9,7 +11,7 @@ This guide will walk you through the steps needed to get an EKS cluster of FIPS-
 
 The process involves creating your custom EKS FIPS AMI using Packer, and then deploying it using ``eksctl``. To test and take a peek inside the cluster, ``kubectl`` can be used.
 
-For non-FIPS clusters, see :doc:`deploy-ubuntu-cluster-with-eks-ami` or :doc:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`. For FIPS on OCI containers, see :doc:`FIPS Ubuntu container <oci:oci-tutorials/fips-ubuntu-container>`.
+For non-FIPS clusters, see :ref:`deploy-ubuntu-cluster-with-eks-ami` or :ref:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`. For FIPS on OCI containers, see :ref:`FIPS Ubuntu container <oci:how-to-fips-ubuntu-container>`.
 
 
 Prerequisites
@@ -86,7 +88,7 @@ Build your image with:
 
 
 
-See also: :doc:`Build a Pro AMI using Packer <../instances/build-pro-ami-using-packer>`.
+See also: :ref:`Build a Pro AMI using Packer <build-pro-ami-using-packer>`.
 Once the build is complete, either:
 
 * :ref:`Create a new cluster (option 1) <create_new_cluster>` or 

--- a/docs/aws/aws-how-to/kubernetes/enable-gpus-on-eks.rst
+++ b/docs/aws/aws-how-to/kubernetes/enable-gpus-on-eks.rst
@@ -2,6 +2,8 @@
    :description: Learn how to enable GPUs on EKS worker nodes. Create a cluster of GPU based instances, install NVIDIA drivers, set up the NVIDIA Container Toolkit, and apply the NVIDIA Device Plugin to the cluster.
 
 
+.. _enable-gpus-on-eks:
+
 Enable GPUs on EKS worker nodes
 ===============================
 
@@ -17,7 +19,7 @@ For the GPU based instances to work, you'll need to install the appropriate `NVI
 
 After installation, use ``sudo nvidia-smi`` to verify that the driver is successfully installed.
 
-For Canonical's own NVIDIA driver installation guide for Ubuntu on AWS, see :doc:`Install NVIDIA drivers <../instances/install-nvidia-drivers>`.
+For Canonical's own NVIDIA driver installation guide for Ubuntu on AWS, see :ref:`Install NVIDIA drivers <install-nvidia-drivers>`.
 
 
 Install and set up the 'NVIDIA Container Toolkit' on each node
@@ -69,7 +71,7 @@ The output should be similar to:
    Applications clocks set to "(MEM 2505, SM 1177)" for GPU 00000000:00:1E.0
    All done.
 
-For details on the kubelet snap used in EKS, see :doc:`EKS kubelet snap <../../aws-reference/eks-kubelet-snap>`.
+For details on the kubelet snap used in EKS, see :ref:`EKS kubelet snap <eks-kubelet-snap>`.
 
 
 Apply 'NVIDIA Device Plugin' to the cluster

--- a/docs/aws/aws-how-to/kubernetes/index.rst
+++ b/docs/aws/aws-how-to/kubernetes/index.rst
@@ -1,13 +1,15 @@
 .. meta::
    :description: List of how-to guides related to using Ubuntu on EKS worker nodes.
 
+.. _kubernetes-index:
+
 Using EKS
 =========
 
 Canonical publishes Ubuntu EKS images ready for use in your EKS clusters. These
 images come pre-configured to join a cluster and are integrated into ``eksctl``,
 the official EKS management CLI tool. Ubuntu LTS and Ubuntu Pro LTS images are
-available via the :doc:`AWS CLI <../../aws-how-to/instances/find-ubuntu-images>`,
+available via the :ref:`AWS CLI <find-ubuntu-images>`,
 ``eksctl``, or the `AWS Marketplace`_.
 
 The following table details the currently supported images and EKS version
@@ -44,10 +46,10 @@ Cluster deployment options for Ubuntu on EKS
 To use Ubuntu as the operating system for your EKS worker nodes, choose from the
 following deployment options:
 
-* :doc:`Deploy an Ubuntu EKS cluster <deploy-ubuntu-cluster-with-eks-ami>`
-* :doc:`Deploy an Ubuntu Pro EKS cluster <deploy-ubuntu-pro-cluster-with-eks-pro-ami>` (using the pre-activated Ubuntu Pro AMI)
-* :doc:`Deploy an Ubuntu Pro FIPS EKS cluster <deploy-ubuntu-pro-fips-cluster>` (using the pre-activated Ubuntu Pro AMI)
-* :doc:`Deploy an Ubuntu Pro cluster using tokens <deploy-ubuntu-pro-cluster>`
+* :ref:`Deploy an Ubuntu EKS cluster <deploy-ubuntu-cluster-with-eks-ami>`
+* :ref:`Deploy an Ubuntu Pro EKS cluster <deploy-ubuntu-pro-cluster-with-eks-pro-ami>` (using the pre-activated Ubuntu Pro AMI)
+* :ref:`Deploy an Ubuntu Pro FIPS EKS cluster <deploy-ubuntu-pro-fips-cluster>` (using the pre-activated Ubuntu Pro AMI)
+* :ref:`Deploy an Ubuntu Pro cluster using tokens <deploy-ubuntu-pro-cluster>`
 
 Deployment options for node groups
 ----------------------------------
@@ -55,8 +57,8 @@ Deployment options for node groups
 You can create both managed and self-managed node groups using Ubuntu on EKS.
 Select from the following options:
 
-* :doc:`Deploy a self-managed Ubuntu node group <deploy-self-managed-node-group>`
-* :doc:`Deploy managed Ubuntu node groups <deploy-managed-node-group>`
+* :ref:`Deploy a self-managed Ubuntu node group <deploy-self-managed-node-group>`
+* :ref:`Deploy managed Ubuntu node groups <deploy-managed-node-group>`
 
 Custom EKS deployments
 ----------------------
@@ -64,7 +66,7 @@ Custom EKS deployments
 For custom configurations, such as GPU-enabled deployments or installing
 Kubeflow, refer to these guides:
 
-* :doc:`Enable GPUs on EKS worker nodes <enable-gpus-on-eks>`
+* :ref:`Enable GPUs on EKS worker nodes <enable-gpus-on-eks>`
 * `Install Kubeflow on EKS (external link)`_
 
 

--- a/docs/aws/aws-how-to/security/index.rst
+++ b/docs/aws/aws-how-to/security/index.rst
@@ -2,6 +2,8 @@
    :description: List of how-to guides related to using security features on Ubuntu-based EC2 instances.
 
 
+.. _security-index:
+
 Using security features
 =======================
 

--- a/docs/aws/aws-how-to/security/use-secureboot-and-vtpm.rst
+++ b/docs/aws/aws-how-to/security/use-secureboot-and-vtpm.rst
@@ -2,6 +2,8 @@
    :description: Learn how to use Secure Boot and vTPM on Ubuntu EC2 instances. Includes steps for using a prebuilt UEFI Secure Boot variable store while registering a new AMI.
 
 
+.. _use-secureboot-and-vtpm:
+
 Use UEFI Secure Boot and TPM on Ubuntu-based EC2 instances
 ==========================================================
 
@@ -51,7 +53,7 @@ The SSM parameter store can be used to get e.g. the latest Ubuntu 22.04 LTS AMI 
        --names /aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id \
        --query 'Parameters[0].Value' --output text)
 
-If you want to use a different Ubuntu image, refer to :doc:`../instances/find-ubuntu-images`. Once you have the AMI ID, 
+If you want to use a different Ubuntu image, refer to :ref:`find-ubuntu-images`. Once you have the AMI ID, 
 use it to get the image name and its snapshot ID. These will be needed during the registration of a new AMI.
 
 .. code-block::

--- a/docs/aws/aws-reference/aws-announcements.rst
+++ b/docs/aws/aws-reference/aws-announcements.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Stay updated with announcements related Ubuntu on AWS, by subscribing to the Ubuntu on AWS discourse channel. Use it to monitor release notes, new products and upcoming features.
 
+.. _aws-announcements:
+
 Ubuntu on AWS Announcements
 ===========================
 

--- a/docs/aws/aws-reference/ec2-credentials.rst
+++ b/docs/aws/aws-reference/ec2-credentials.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Overview of EC2 credentials for AWS, including sign-in credentials, access keys, X.509 certificates, and SSH key pairs.
 
+.. _ec2-credentials:
+
 EC2 credentials
 ===============
 

--- a/docs/aws/aws-reference/eks-kubelet-snap.rst
+++ b/docs/aws/aws-reference/eks-kubelet-snap.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Details about the kubelet-eks snap for EKS worker nodes, including channels, updates, and snap management.
 
+.. _eks-kubelet-snap:
+
 EKS kubelet snap
 ================
 
@@ -16,7 +18,7 @@ Note that the `latest` channel track of the snap is unused.
 See the `official snap documentation <https://snapcraft.io/docs/channels>`_ for more information
 about the concept of channels and tracks.
 
-For an overview of all snaps bundled in EKS worker images, see :doc:`Snap usage in EKS worker images <../aws-explanation/eks-snaps>`.
+For an overview of all snaps bundled in EKS worker images, see :ref:`Snap usage in EKS worker images <eks-snaps>`.
 
 Automatic snap updates
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/aws/aws-reference/index.rst
+++ b/docs/aws/aws-reference/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Reference documentation for Ubuntu on AWS, including EC2 credentials, EKS snaps, Pro features, and support options.
 
+.. _aws-reference-index:
+
 Reference
 =========
 
@@ -10,26 +12,26 @@ EC2-related
 -----------
 Information about the different types of EC2 credentials, including how to obtain them and use them to access Ubuntu images on AWS.
 
-* :doc:`EC2 credentials <ec2-credentials>`
+* :ref:`EC2 credentials <ec2-credentials>`
 
 EKS-related
 ------------
 Details about the kubelet snap that EKS worker nodes use.
 
-* :doc:`EKS kubelet snap <eks-kubelet-snap>`
+* :ref:`EKS kubelet snap <eks-kubelet-snap>`
 
 Support-related
 -----------------
 Details about the support options available for Ubuntu on AWS.
 
-* :doc:`Ubuntu Pro on AWS <pro>`
-* :doc:`Support options on AWS <support>`
+* :ref:`Ubuntu Pro on AWS <pro>`
+* :ref:`Support options on AWS <support>`
 
 Announcements
 -----------------
 Keep track of the latest announcements related to Ubuntu on AWS.
 
-* :doc:`Ubuntu on AWS Announcements <aws-announcements>`
+* :ref:`Ubuntu on AWS Announcements <aws-announcements>`
 
 .. toctree::
    :hidden:

--- a/docs/aws/aws-reference/pro.rst
+++ b/docs/aws/aws-reference/pro.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Ubuntu Pro on AWS, including ESM, Livepatch, compliance, and Pro image availability for cloud workloads.
 
+.. _pro:
+
 Ubuntu Pro on AWS
 =================
 
@@ -12,7 +14,7 @@ Ubuntu Pro availability on AWS
 
 Ubuntu Pro on AWS is available through different methods:
 
-:doc:`Launch new Amazon Images (AMIs) <../aws-how-to/instances/launch-ubuntu-ec2-instance>`,
+:ref:`Launch new Amazon Images (AMIs) <launch-ubuntu-ec2-instance>`,
 covering the following products:
 
 * Ubuntu Pro server images: EC2, Marketplace
@@ -24,13 +26,13 @@ covering the following products:
 
 In-place upgrade of existing Ubuntu LTS instances to Ubuntu Pro:
 
-* :doc:`Using AWS License Manager <../aws-how-to/instances/upgrade-in-place-from-lts-to-pro>`: EC2, Marketplace (coming soon)
+* :ref:`Using AWS License Manager <upgrade-in-place-from-lts-to-pro>`: EC2, Marketplace (coming soon)
 * Using Canonical Tokens: Marketplace (contact us)
 
 Build custom AMIs using EC2 Image Builder:
 
 * Starting from any base Ubuntu Pro image: EC2, Marketplace
-* Using the :doc:`Upgrade to Ubuntu Pro component <../aws-how-to/instances/build-ubuntu-pro-image-with-ec2-image-builder>`: Marketplace
+* Using the :ref:`Upgrade to Ubuntu Pro component <build-ubuntu-pro-image-with-ec2-image-builder>`: Marketplace
 
 Ubuntu Pro features overview
 ----------------------------

--- a/docs/aws/aws-reference/support.rst
+++ b/docs/aws/aws-reference/support.rst
@@ -1,12 +1,14 @@
 .. meta::
    :description: Overview of support options on AWS, including Canonical support via Ubuntu Pro and Amazon front line support channels and bug reporting options.
 
+.. _support:
+
 Support options on AWS
 ============================
 
 Ubuntu Pro on AWS
 -----------------
-Ubuntu Pro provides numerous support options. Please see the :doc:`Pro <pro>` page for 
+Ubuntu Pro provides numerous support options. Please see the :ref:`Pro <pro>` page for 
 more details.
 
 

--- a/docs/aws/index.rst
+++ b/docs/aws/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover Ubuntu on AWS, including optimized images, deployment guides, technical reference, and best practices for cloud workloads.
 
+.. _index:
+
 Ubuntu on AWS
 =============
 
@@ -33,10 +35,10 @@ Canonical provides a range of optimized Ubuntu images and services tailored for 
    :widths: 35 65
 
    * - **Canonical's offerings**
-     - :doc:`AWS optimizations <aws-explanation/canonical-offerings>` • :doc:`Ubuntu Pro on AWS <aws-reference/pro>` • :doc:`Support options <aws-reference/support>`
+     - :ref:`AWS optimizations <canonical-offerings>` • :ref:`Ubuntu Pro on AWS <pro>` • :ref:`Support options <support>`
 
    * - **Canonical's policies**
-     - :doc:`Security aspects <aws-explanation/ubuntu-security-on-aws>` • :doc:`Image testing <aws-explanation/aws-image-testing>` • :doc:`Image retention policy <aws-explanation/ec2-image-retention-policy>` • :doc:`Ubuntu on AWS Announcements <aws-reference/aws-announcements>`
+     - :ref:`Security aspects <ubuntu-security-on-aws>` • :ref:`Image testing <aws-image-testing>` • :ref:`Image retention policy <ec2-image-retention-policy>` • :ref:`Ubuntu on AWS Announcements <aws-announcements>`
      
      
 
@@ -49,19 +51,19 @@ Ubuntu on EC2 offers a flexible foundation for running cloud workloads, from lau
    :widths: 35 65
 
    * - **Finding images and launching instances**
-     - :doc:`EC2 credentials <aws-reference/ec2-credentials>` • :doc:`Launch an instance using CLI <aws-how-to/instances/launch-ubuntu-ec2-instance>` • :doc:`Find images <aws-how-to/instances/find-ubuntu-images>` • :doc:`Launch a desktop <aws-how-to/instances/launch-ubuntu-desktop>` • :doc:`Import a local Ubuntu VM into AWS <aws-how-to/instances/import-local-vm-to-aws>`
+     - :ref:`EC2 credentials <ec2-credentials>` • :ref:`Launch an instance using CLI <launch-ubuntu-ec2-instance>` • :ref:`Find images <find-ubuntu-images>` • :ref:`Launch a desktop <launch-ubuntu-desktop>` • :ref:`Import a local Ubuntu VM into AWS <import-local-vm-to-aws>`
 
    * - **Creating AMIs and templates**
-     - :doc:`Build an Ubuntu Pro AMI using Packer <aws-how-to/instances/build-pro-ami-using-packer>` • :doc:`Build a custom Ubuntu Pro image with EC2 Image Builder <aws-how-to/instances/build-ubuntu-pro-image-with-ec2-image-builder>` • :doc:`Create CloudFormation templates <aws-how-to/instances/build-cloudformation-templates>` 
+     - :ref:`Build an Ubuntu Pro AMI using Packer <build-pro-ami-using-packer>` • :ref:`Build a custom Ubuntu Pro image with EC2 Image Builder <build-ubuntu-pro-image-with-ec2-image-builder>` • :ref:`Create CloudFormation templates <build-cloudformation-templates>` 
 
    * - **Custom configurations**
-     - :doc:`Install 64K page kernel <aws-how-to/instances/install-64k-kernel>` • :doc:`install NVIDIA drivers <aws-how-to/instances/install-nvidia-drivers>` • :doc:`Configure multiple NICs <aws-how-to/instances/automatically-setup-multiple-nics>` • :doc:`Use UEFI secure boot and TPM <aws-how-to/security/use-secureboot-and-vtpm>` • :doc:`Launch and attest an AMD SEV-SNP instance <aws-how-to/instances/launch-and-attest-amd-sev-snp-instances>` • :doc:`Complete hardening of a base CIS Level 1 instance <aws-how-to/instances/cis-hardening>` 
+     - :ref:`Install 64K page kernel <install-64k-kernel>` • :ref:`install NVIDIA drivers <install-nvidia-drivers>` • :ref:`Configure multiple NICs <automatically-setup-multiple-nics>` • :ref:`Use UEFI secure boot and TPM <use-secureboot-and-vtpm>` • :ref:`Launch and attest an AMD SEV-SNP instance <launch-and-attest-amd-sev-snp-instances>` • :ref:`Complete hardening of a base CIS Level 1 instance <cis_post_deploy_hardening>` 
 
    * - **Upgrades and maintenance**
-     - :doc:`Perform in-place upgrade to Ubuntu Pro <aws-how-to/instances/upgrade-in-place-from-lts-to-pro>` • :doc:`Upgrade Ubuntu LTS release <aws-how-to/instances/upgrade-ubuntu-lts-release>` • :doc:`Upgrade to Ubuntu Pro at scale using tokens with SSM <aws-how-to/instances/upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm>` •  :doc:`Configure automated updates <aws-how-to/instances/automatically-update-ubuntu-instances>`
+     - :ref:`Perform in-place upgrade to Ubuntu Pro <upgrade-in-place-from-lts-to-pro>` • :ref:`Upgrade Ubuntu LTS release <upgrade-ubuntu-lts-release>` • :ref:`Upgrade to Ubuntu Pro at scale using tokens with SSM <upgrade-to-ubuntu-pro-at-scale-using-tokens-with-ssm>` •  :ref:`Configure automated updates <automatically-update-ubuntu-instances>`
 
    * - **Using Canonical products**
-     - :doc:`Deploy Canonical Data Science Stack <aws-how-to/instances/data-science-stack-on-ec2>`
+     - :ref:`Deploy Canonical Data Science Stack <data-science-stack-on-ec2>`
      
 
 Ubuntu on EKS
@@ -73,19 +75,19 @@ Ubuntu on EKS provides secure, optimized worker node images for Amazon's managed
    :widths: 35 65
 
    * - **Using Ubuntu AMIs for worker nodes**
-     - :doc:`Deploy Ubuntu EKS cluster <aws-how-to/kubernetes/deploy-ubuntu-cluster-with-eks-ami>` • :doc:`Deploy Ubuntu Pro EKS cluster <aws-how-to/kubernetes/deploy-ubuntu-pro-cluster-with-eks-pro-ami>` • :doc:`Deploy Ubuntu Pro FIPS EKS cluster <aws-how-to/kubernetes/deploy-ubuntu-pro-fips-cluster>` 
+     - :ref:`Deploy Ubuntu EKS cluster <deploy-ubuntu-cluster-with-eks-ami>` • :ref:`Deploy Ubuntu Pro EKS cluster <deploy-ubuntu-pro-cluster-with-eks-pro-ami>` • :ref:`Deploy Ubuntu Pro FIPS EKS cluster <deploy-ubuntu-pro-fips-cluster>` 
 
    * - **Using pro tokens for worker nodes**
-     - :doc:`Deploy Ubuntu Pro EKS cluster  <aws-how-to/kubernetes/deploy-ubuntu-pro-cluster>` 
+     - :ref:`Deploy Ubuntu Pro EKS cluster <deploy-ubuntu-pro-cluster>` 
 
    * - **Deploying Ubuntu node groups**
-     - :doc:`Deploy self-managed node groups <aws-how-to/kubernetes/deploy-self-managed-node-group>` • :doc:`Deploy managed node groups <aws-how-to/kubernetes/deploy-managed-node-group>` 
+     - :ref:`Deploy self-managed node groups <deploy-self-managed-node-group>` • :ref:`Deploy managed node groups <deploy-managed-node-group>` 
 
    * - **Custom configurations**
-     - :doc:`Enable GPUs on EKS <aws-how-to/kubernetes/enable-gpus-on-eks>` • `Install Kubeflow on EKS <https://documentation.ubuntu.com/charmed-kubeflow/how-to/install/install-eks/>`_ 
+     - :ref:`Enable GPUs on EKS <enable-gpus-on-eks>` • `Install Kubeflow on EKS <https://documentation.ubuntu.com/charmed-kubeflow/how-to/install/install-eks/>`_ 
 
    * - **EKS snaps**
-     - :doc:`Snap usage in EKS worker images <aws-explanation/eks-snaps>` • :doc:`EKS kubelet snap <aws-reference/eks-kubelet-snap>` 
+     - :ref:`Snap usage in EKS worker images <eks-snaps>` • :ref:`EKS kubelet snap <eks-kubelet-snap>` 
 
      
 
@@ -97,11 +99,11 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides  <aws-how-to/index>` assume you have basic familiarity with Ubuntu images on AWS and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on EC2 and EKS. 
+* :ref:`How-to guides <aws-how-to-index>` assume you have basic familiarity with Ubuntu images on AWS and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on EC2 and EKS. 
 
-* :doc:`Reference <aws-reference/index>` includes technical information about Ubuntu on AWS, such EC2 credentials, EKS snaps, Ubuntu Pro and the support options available on AWS.
+* :ref:`Reference <aws-reference-index>` includes technical information about Ubuntu on AWS, such EC2 credentials, EKS snaps, Ubuntu Pro and the support options available on AWS.
 
-* :doc:`Explanation <aws-explanation/index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings, our image retention policy and the usage of snaps in our EKS images.
+* :ref:`Explanation <aws-explanation-index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings, our image retention policy and the usage of snaps in our EKS images.
 
 ---------
 
@@ -118,7 +120,7 @@ Get involved
 * `Join our online chat`_
 * `Discuss on Matrix`_
 * `Talk to us about Ubuntu on AWS`_
-* :doc:`aws-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 If none of the above options are suitable for you, and you still want to get in touch, send us an email: aws@canonical.com.
 

--- a/docs/azure/azure-explanation/canonical-offerings.rst
+++ b/docs/azure/azure-explanation/canonical-offerings.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Canonical's Ubuntu image offerings on Azure, including Pro, minimal, CVM, and CIS-hardened images for cloud workloads. Includes details about kernel variants and collaborative optimizations done with Microsoft.
 
+.. _canonical-offerings:
+
 Canonical's offerings on Azure
 ==============================
 
@@ -12,7 +14,7 @@ Ubuntu images are specifically fine-tuned to maximize performance on Azure infra
 
 * `Server images`_ are general-purpose images customized for Azure Virtual Machines. These images are also available with `Ubuntu Pro`_ enabled.
 
-* :doc:`Minimal images <all-clouds:all-clouds-explanation/ubuntu-base-and-minimal-images>` are designed for automated deployment at scale with a reduced default package set. Things like interactive usage tools are omitted. They are much smaller, boot faster, and require fewer security updates over time due to the fewer installed packages. These images are also available with `Ubuntu Pro`_ enabled.
+* :ref:`Minimal images <all-clouds:ubuntu-base-and-minimal-images>` are designed for automated deployment at scale with a reduced default package set. Things like interactive usage tools are omitted. They are much smaller, boot faster, and require fewer security updates over time due to the fewer installed packages. These images are also available with `Ubuntu Pro`_ enabled.
 
 *  :ref:`Confidential Virtual Machine (CVM) images <azure-cvms>` provide enhanced security features designed to protect data at rest, in use, and during boot. CVM images are intended for use with Azure's confidential computing capabilities using hardware-enabled security features. These images are also available with `Ubuntu Pro`_ enabled.
 
@@ -24,7 +26,7 @@ Ubuntu images are specifically fine-tuned to maximize performance on Azure infra
 
 * `Ubuntu Pro Minimal CIS images`_ are built on Ubuntu Pro and are CIS-hardened with a minimal footprint to maximize security. These images are available with CIS Level 1 or CIS Level 2 hardening.
 
-The availability of each of these images and the means to find them on Azure is described in the :doc:`Find Ubuntu images <../azure-how-to/instances/find-ubuntu-images/>` page.
+The availability of each of these images and the means to find them on Azure is described in the :ref:`Find Ubuntu images <find-ubuntu-images>` page.
 
 Optimizations for Azure
 -----------------------
@@ -52,7 +54,7 @@ Collaborative Optimizations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. `Anbox on Azure`_, that allows users to run Android apps on Azure at scale
-#. Collaboration with Azure's AKS team to support the :doc:`Azure Kubernetes worker node <ubuntu-on-aks-worker-nodes>` image, as these worker nodes nearly always run Ubuntu
+#. Collaboration with Azure's AKS team to support the :ref:`Azure Kubernetes worker node <ubuntu-on-aks-worker-nodes>` image, as these worker nodes nearly always run Ubuntu
 #. Collaboration with the Azure Guest Patching Service and Update Manager teams to ensure simple security patch management for users
 #. Collaboration with the .Net team on `Chiseled .Net images`_ that have a smaller size and security cross-section
 #. `Landscape on Azure`_, for managing your Ubuntu deployments at scale

--- a/docs/azure/azure-explanation/image-retention-policy.rst
+++ b/docs/azure/azure-explanation/image-retention-policy.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand the Ubuntu image retention policy on Azure, including release and daily image lifecycles and marketplace availability.
 
+.. _image-retention-policy:
+
 Image retention policy
 ======================
 
@@ -8,7 +10,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`. 
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`. 
 
 On Azure, *release* and *daily* images for a given Ubuntu release are published under two distinct offers. To avoid confusion, only *release* images of Ubuntu are displayed on the Azure Marketplace and *daily* images are 'hidden'.
 

--- a/docs/azure/azure-explanation/index.rst
+++ b/docs/azure/azure-explanation/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Explanations of Ubuntu on Azure offerings, security, image retention, and package maintenance policies.
 
+.. _azure-explanation-index:
+
 Explanation
 ===========
 
@@ -11,10 +13,10 @@ Our offerings
 
 Details about our offerings, including the different types of images available, the Azure-specific optimizations and the packages that we maintain for Azure:
 
-* :doc:`Ubuntu on Azure <understanding-ubuntu-on-azure>`
-* :doc:`Canonical's offerings on Azure <canonical-offerings>`
-* :doc:`Ubuntu on AKS<ubuntu-on-aks-worker-nodes>`
-* :doc:`Packages maintained by Canonical for Azure<packages>`
+* :ref:`Ubuntu on Azure <understanding-ubuntu-on-azure>`
+* :ref:`Canonical's offerings on Azure <canonical-offerings>`
+* :ref:`Ubuntu on AKS <ubuntu-on-aks-worker-nodes>`
+* :ref:`Packages maintained by Canonical for Azure <packages>`
 
 
 Our policies
@@ -22,8 +24,8 @@ Our policies
 
 Our policies such as the security features available via Ubuntu and Ubuntu Pro and our image retention policy:
  
-* :doc:`Security overview<security-overview>`
-* :doc:`Image retention policy<image-retention-policy>`
+* :ref:`Security overview <security-overview>`
+* :ref:`Image retention policy <image-retention-policy>`
 
 .. toctree::
    :hidden:

--- a/docs/azure/azure-explanation/packages.rst
+++ b/docs/azure/azure-explanation/packages.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: List of packages maintained by Canonical for Ubuntu cloud images on Azure, including walinuxagent, azure-proxy-agent and azure-vm-utils.
 
+.. _packages:
+
 Packages maintained by Canonical for Azure
 ==========================================
 

--- a/docs/azure/azure-explanation/security-overview.rst
+++ b/docs/azure/azure-explanation/security-overview.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about security features available with Ubuntu images on Azure, including Trusted Launch, CVMs, and Ubuntu Pro enhancements.
 
+.. _security-overview:
+
 Ubuntu Security on Azure
 ========================
 
@@ -9,7 +11,7 @@ Ubuntu images on Azure include the security features provided by both Ubuntu and
 Ubuntu security features
 ------------------------
 
-Ubuntu on Azure inherits and benefits from all of the security features available to Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on Azure inherits and benefits from all of the security features available to Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 Azure security features
 -----------------------
@@ -32,7 +34,7 @@ Apart from the trusted execution environments (TEE) provided by these specialize
 
 For confidential AI workloads, the security model also extends to GPU processing through the NVIDIA H100 Tensor Core GPU, which implements its own TEE with encrypted data transfer between the CPU and GPU.
 
-To launch Ubuntu Confidential VMs, refer to :doc:`../azure-how-to/instances/launch-ubuntu-images`. It's important to note that though memory encryption is always enabled (via the TEE) with a confidential VM, full-disk encryption (FDE) is optional, and it requires explicit activation after the VM is provisioned.
+To launch Ubuntu Confidential VMs, refer to :ref:`launch-ubuntu-images`. It's important to note that though memory encryption is always enabled (via the TEE) with a confidential VM, full-disk encryption (FDE) is optional, and it requires explicit activation after the VM is provisioned.
 
 To better understand the concepts of secure boot, measured boot, FDE and CVMs, refer to the relevant sections in our `generic cloud security overview page`_.
 
@@ -46,7 +48,7 @@ Apart from the Ubuntu Server images, Azure also has images for `Ubuntu Pro`_, wh
 * Live kernel updates: These reduce downtime and unplanned reboots in case of kernel vulnerabilities.
 * FIPS compliance: Includes FIPS-certified modules to enable the use of Ubuntu in highly regulated environments.
 
-To find Ubuntu Pro images on Azure, refer to :doc:`../azure-how-to/instances/find-ubuntu-images`. 
+To find Ubuntu Pro images on Azure, refer to :ref:`find-ubuntu-images`. 
 
 
 .. _`Ubuntu security page`: https://ubuntu.com/security

--- a/docs/azure/azure-explanation/ubuntu-on-aks-worker-nodes.rst
+++ b/docs/azure/azure-explanation/ubuntu-on-aks-worker-nodes.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Overview of Ubuntu as the default OS for Azure Kubernetes Service (AKS) worker nodes, including updates and customization.
 
+.. _ubuntu-on-aks-worker-nodes:
+
 Ubuntu on AKS worker nodes
 ==========================
 

--- a/docs/azure/azure-explanation/understanding-ubuntu-on-azure.rst
+++ b/docs/azure/azure-explanation/understanding-ubuntu-on-azure.rst
@@ -1,13 +1,15 @@
 .. meta::
    :description: Answers to common questions about Ubuntu on Azure, including image availability, refresh, deprecation, and customizations.
 
+.. _understanding-ubuntu-on-azure:
+
 Understanding Ubuntu on Azure
 =============================
 -----------------------------
 Is Ubuntu available on Azure?
 -----------------------------
 
-Yes, all the supported versions of Ubuntu are available for free on Azure. See: :doc:`../azure-how-to/instances/find-ubuntu-images`.
+Yes, all the supported versions of Ubuntu are available for free on Azure. See: :ref:`find-ubuntu-images`.
 
 ------------------------------------------------------
 Why are there multiple offers from Canonical on Azure?

--- a/docs/azure/azure-how-to/contribute-to-these-docs.rst
+++ b/docs/azure/azure-how-to/contribute-to-these-docs.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to contribute to Ubuntu on Azure documentation, including editing, building, and submitting pull requests.
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/azure/azure-how-to/index.rst
+++ b/docs/azure/azure-how-to/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: List of how-to guides for launching, managing, and upgrading Ubuntu on Azure, including image selection and solution deployment.
 
+.. _azure-how-to-index:
+
 How-to guides
 =============
 
@@ -11,34 +13,34 @@ Finding and launching images
 
 Use the Azure CLI to find and launch appropriate images:
 
-* :doc:`Install Azure CLI <instances/install-azure-cli>`
-* :doc:`Find images <instances/find-ubuntu-images>`
-* :doc:`Launch images <instances/launch-ubuntu-images>`
+* :ref:`Install Azure CLI <install-azure-cli>`
+* :ref:`Find images <find-ubuntu-images>`
+* :ref:`Launch images <launch-ubuntu-images>`
 
 Upgrades and maintenance
 ------------------------
 
 Since security is always an important consideration, you might want to check for available security upgrades, install Ubuntu Pro and perform relevant upgrades:
 
-* :doc:`Check for available security updates <instances/check-available-security-updates>`
-* :doc:`Get Ubuntu Pro <instances/get-ubuntu-pro>`
-* :doc:`Upgrade Ubuntu LTS release <instances/upgrade-ubuntu-lts-release>`
+* :ref:`Check for available security updates <check-available-security-updates>`
+* :ref:`Get Ubuntu Pro <get-ubuntu-pro>`
+* :ref:`Upgrade Ubuntu LTS release <upgrade-ubuntu-lts-release>`
 
 Creating golden images
 -----------------------
 
 You can create golden images to simplify your estate management:
 
-* :doc:`Create a Pro golden image <instances/create-pro-fips-golden-image>`
-* :doc:`Create a golden image pipeline <instances/create-a-golden-image-pipeline>`
+* :ref:`Create a Pro golden image <create-pro-fips-golden-image>`
+* :ref:`Create a golden image pipeline <create-a-golden-image-pipeline>`
 
 Custom deployments
 ------------------
 If you want to deploy specific solutions like SQL Server and Kubeflow on Azure, use:
 
-* :doc:`Deploy an Ubuntu VM with SQL Server <instances/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure>`
+* :ref:`Deploy an Ubuntu VM with SQL Server <provision-an-ubuntu-virtual-machine-running-sql-server-in-azure>`
 * `Install Kubeflow on AKS (external link)`_
-* :doc:`Deploy Kubeflow with AKS spot instances <instances/deploy-kubeflow-pipelines-with-aks-spot-instances>`
+* :ref:`Deploy Kubeflow with AKS spot instances <deploy-kubeflow-pipelines-with-aks-spot-instances>`
 
 .. toctree::
    :hidden:

--- a/docs/azure/azure-how-to/instances/check-available-security-updates.rst
+++ b/docs/azure/azure-how-to/instances/check-available-security-updates.rst
@@ -2,6 +2,8 @@
    :description: Learn how to check for available security updates using Azure Update Manager. Includes instructions for assessing updates on individual VMs and across multiple VMs.
 
 
+.. _check-available-security-updates:
+
 Check for available security updates using Azure Update Manager
 ================================================================
 

--- a/docs/azure/azure-how-to/instances/create-a-golden-image-pipeline.rst
+++ b/docs/azure/azure-how-to/instances/create-a-golden-image-pipeline.rst
@@ -2,12 +2,14 @@
    :description: Step-by-step guide to create Ubuntu golden image pipelines with GitHub Actions and Azure Image Builder. Includes detailed instructions and best practices.
 
 
+.. _create-a-golden-image-pipeline:
+
 Create an Ubuntu golden image pipeline
 ======================================
 
 You can use GitHub Actions to create a pipeline for building Ubuntu "golden" images with the Azure Image Builder (AIB). Creating an automated pipeline is a great way to ensure that your golden image is kept up to date with the latest security and bug fixes. 
 
-The focus here is on automating the use of AIB. If you want more information about how to use AIB see the :doc:`Create a Pro golden image <create-pro-fips-golden-image>` guide which explains the individual steps.
+The focus here is on automating the use of AIB. If you want more information about how to use AIB see the :ref:`Create a Pro golden image <create-pro-fips-golden-image>` guide which explains the individual steps.
 
 
 Prerequisites

--- a/docs/azure/azure-how-to/instances/create-pro-fips-golden-image.rst
+++ b/docs/azure/azure-how-to/instances/create-pro-fips-golden-image.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create Ubuntu Pro golden images with Azure Image Builder. Includes steps for setting up an Azure Compute Gallery and creating the golden image from a configuration template.
 
 
+.. _create-pro-fips-golden-image:
+
 Create an Ubuntu Pro golden image with Azure Image Builder
 ===============================================================
 
@@ -56,7 +58,7 @@ Create a variable for your subscription ID:
 
     subscriptionID=$(az account show --query id --output tsv)
 
-Create variables for gallery name, image definition name and Ubuntu Pro plan to be used. See :doc:`Find Ubuntu images on Azure <find-ubuntu-images>` for a full list of available Pro images. If you have an Ubuntu Pro private offer with Canonical you'll have a custom offer and SKU which should be used.
+Create variables for gallery name, image definition name and Ubuntu Pro plan to be used. See :ref:`Find Ubuntu images on Azure <find-ubuntu-images>` for a full list of available Pro images. If you have an Ubuntu Pro private offer with Canonical you'll have a custom offer and SKU which should be used.
 
 .. tabs::
 

--- a/docs/azure/azure-how-to/instances/deploy-kubeflow-pipelines-with-aks-spot-instances.rst
+++ b/docs/azure/azure-how-to/instances/deploy-kubeflow-pipelines-with-aks-spot-instances.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy Kubeflow pipelines on AKS using spot instances. Includes steps for adding spot instances to an AKS cluster and updating the pipeline to allow task execution on them.
 
    
+.. _deploy-kubeflow-pipelines-with-aks-spot-instances:
+
 Deploy Kubeflow pipelines with AKS spot instances
 =================================================
 

--- a/docs/azure/azure-how-to/instances/find-ubuntu-images.rst
+++ b/docs/azure/azure-how-to/instances/find-ubuntu-images.rst
@@ -2,6 +2,8 @@
    :description: Learn how to find and select different Ubuntu images on Microsoft Azure. Includes URNs for LTS, interim releases, Pro, CVM, FIPS-compliant, and CIS-hardened images published by Canonical. 
 
 
+.. _find-ubuntu-images:
+
 Find Ubuntu images on Azure
 ============================
 

--- a/docs/azure/azure-how-to/instances/get-ubuntu-pro.rst
+++ b/docs/azure/azure-how-to/instances/get-ubuntu-pro.rst
@@ -2,6 +2,8 @@
    :description: Learn how to get Ubuntu Pro on Microsoft Azure. Includes instructions for enabling Ubuntu Pro on new and running instances, as well as verification steps to confirm Pro features are active.
 
 
+.. _get-ubuntu-pro:
+
 Get Ubuntu Pro on Azure
 =======================
 

--- a/docs/azure/azure-how-to/instances/install-azure-cli.rst
+++ b/docs/azure/azure-how-to/instances/install-azure-cli.rst
@@ -2,6 +2,8 @@
    :description: Learn how to install and configure Azure CLI on Ubuntu systems. Includes instructions for adding the Microsoft repository and installing the CLI from there.
 
 
+.. _install-azure-cli:
+
 Install Azure CLI on Ubuntu
 ============================
 

--- a/docs/azure/azure-how-to/instances/launch-ubuntu-images.rst
+++ b/docs/azure/azure-how-to/instances/launch-ubuntu-images.rst
@@ -2,6 +2,8 @@
    :description: Learn how to launch Ubuntu virtual machines on Azure. Includes instructions for creating resource groups and launching VMs using the Azure CLI, with specific guidance for ARM64 and Confidential VM images.
 
 
+.. _launch-ubuntu-images:
+
 Launch Ubuntu images on Azure
 =============================
 
@@ -14,7 +16,7 @@ Prerequisites
 
 - Microsoft Azure account
 - Azure CLI
-- Uniform Resource Name (URN) for an Ubuntu image (see :doc:`find-ubuntu-images`)
+- Uniform Resource Name (URN) for an Ubuntu image (see :ref:`find-ubuntu-images`)
 
 Azure CLI commands in this guide share some declared variables:
 

--- a/docs/azure/azure-how-to/instances/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure.rst
+++ b/docs/azure/azure-how-to/instances/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure.rst
@@ -2,6 +2,8 @@
    :description: Learn how to provision Ubuntu VMs running SQL Server on Azure. Includes steps for launching a pre-installled SQL Server VM, configuring password, and enabling remote connections.
 
 
+.. _provision-an-ubuntu-virtual-machine-running-sql-server-in-azure:
+
 Provision an Ubuntu virtual machine running SQL Server in Azure
 ===============================================================
 
@@ -19,7 +21,7 @@ SQL Server support varies per Ubuntu version. Consult the `SQL Server on Ubuntu 
 
 Pick an Ubuntu image
 --------------------
-Once you know what Ubuntu version you need you can consult :doc:`How to Find Ubuntu Images on Azure <find-ubuntu-images>` to find all Ubuntu offerings on Azure. If you are unsure about which Ubuntu product to use (Pro vs non-Pro, FIPS etc.) see :doc:`Canonical's offerings on Azure <../../azure-explanation/canonical-offerings>` for an explanation.
+Once you know what Ubuntu version you need you can consult :ref:`How to Find Ubuntu Images on Azure <find-ubuntu-images>` to find all Ubuntu offerings on Azure. If you are unsure about which Ubuntu product to use (Pro vs non-Pro, FIPS etc.) see :ref:`Canonical's offerings on Azure <canonical-offerings>` for an explanation.
 
 Launching an Ubuntu VM
 ----------------------
@@ -27,11 +29,11 @@ Once you have chosen your image you have two options for creating your VM.
 
 With Azure Portal
 ~~~~~~~~~~~~~~~~~
-Click the the "Quick start" link for your image in :doc:`How to Find Ubuntu Images on Azure <find-ubuntu-images>`. This will take you to the `Azure Portal <https://portal.azure.com/>`_ where you will be guided through the VM creation process.
+Click the the "Quick start" link for your image in :ref:`How to Find Ubuntu Images on Azure <find-ubuntu-images>`. This will take you to the `Azure Portal <https://portal.azure.com/>`_ where you will be guided through the VM creation process.
 
 With Azure CLI
 ~~~~~~~~~~~~~~
-Take the URN for your image in :doc:`How to Find Ubuntu Images on Azure <find-ubuntu-images>` and then follow :doc:`How to Launch Ubuntu images on Azure <launch-ubuntu-images>` to create the VM with the Azure CLI.
+Take the URN for your image in :ref:`How to Find Ubuntu Images on Azure <find-ubuntu-images>` and then follow :ref:`How to Launch Ubuntu images on Azure <launch-ubuntu-images>` to create the VM with the Azure CLI.
 
 Install and configure SQL Server
 --------------------------------

--- a/docs/azure/azure-how-to/instances/upgrade-ubuntu-lts-release.rst
+++ b/docs/azure/azure-how-to/instances/upgrade-ubuntu-lts-release.rst
@@ -2,6 +2,8 @@
    :description: Learn how to upgrade from one Ubuntu LTS release to the next on Azure virtual machines.
 
 
+.. _upgrade-ubuntu-lts-release:
+
 Upgrade Ubuntu LTS release on Azure
 ===================================
 

--- a/docs/azure/azure-reference/support.rst
+++ b/docs/azure/azure-reference/support.rst
@@ -1,3 +1,5 @@
+.. _support:
+
 Support options on Azure
 ========================
 

--- a/docs/azure/index.rst
+++ b/docs/azure/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover Ubuntu on Azure, including optimized images, deployment guides, technical reference, and best practices for cloud workloads.
 
+.. _index:
+
 Ubuntu on Azure
 ===============
 
@@ -28,22 +30,22 @@ In this documentation
     :header-rows: 0
 
     * - **Canonical's offerings**
-      - :doc:`Azure optimizations <azure-explanation/canonical-offerings>` • :doc:`Ubuntu on AKS <azure-explanation/ubuntu-on-aks-worker-nodes>` • :doc:`Support options <azure-reference/support>` • :doc:`Packages maintained <azure-explanation/packages>` • :doc:`Understanding Ubuntu on Azure <azure-explanation/understanding-ubuntu-on-azure>` 
+      - :ref:`Azure optimizations <canonical-offerings>` • :ref:`Ubuntu on AKS <ubuntu-on-aks-worker-nodes>` • :ref:`Support options <support>` • :ref:`Packages maintained <packages>` • :ref:`Understanding Ubuntu on Azure <understanding-ubuntu-on-azure>` 
       
     * - **Finding and launching images**
-      - :doc:`Install Azure CLI <azure-how-to/instances/install-azure-cli>` • :doc:`Find images <azure-how-to/instances/find-ubuntu-images>` • :doc:`Launch images <azure-how-to/instances/launch-ubuntu-images>` 
+      - :ref:`Install Azure CLI <install-azure-cli>` • :ref:`Find images <find-ubuntu-images>` • :ref:`Launch images <launch-ubuntu-images>` 
       
     * - **Upgrades and maintenance**
-      - :doc:`Check for available security updates <azure-how-to/instances/check-available-security-updates>` • :doc:`Get Ubuntu Pro <azure-how-to/instances/get-ubuntu-pro>` • :doc:`Upgrade Ubuntu LTS release <azure-how-to/instances/upgrade-ubuntu-lts-release>` 
+      - :ref:`Check for available security updates <check-available-security-updates>` • :ref:`Get Ubuntu Pro <get-ubuntu-pro>` • :ref:`Upgrade Ubuntu LTS release <upgrade-ubuntu-lts-release>` 
       
     * - **Creating golden images**
-      - :doc:`Create a Pro golden image <azure-how-to/instances/create-pro-fips-golden-image>` • :doc:`Create a golden image pipeline <azure-how-to/instances/create-a-golden-image-pipeline>` 
+      - :ref:`Create a Pro golden image <create-pro-fips-golden-image>` • :ref:`Create a golden image pipeline <create-a-golden-image-pipeline>` 
 
     * - **Custom deployments**
-      - :doc:`Deploy an Ubuntu VM with SQL Server <azure-how-to/instances/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure>` • `Install Kubeflow on AKS <https://documentation.ubuntu.com/charmed-kubeflow/latest/how-to/install/install-aks/>`_ • :doc:`Deploy Kubeflow with AKS spot instances <azure-how-to/instances/deploy-kubeflow-pipelines-with-aks-spot-instances>` 
+      - :ref:`Deploy an Ubuntu VM with SQL Server <provision-an-ubuntu-virtual-machine-running-sql-server-in-azure>` • `Install Kubeflow on AKS <https://documentation.ubuntu.com/charmed-kubeflow/latest/how-to/install/install-aks/>`_ • :ref:`Deploy Kubeflow with AKS spot instances <deploy-kubeflow-pipelines-with-aks-spot-instances>` 
       
     * - **Policies**
-      - :doc:`Security aspects <azure-explanation/security-overview>` • :doc:`Image retention policy <azure-explanation/image-retention-policy>`  
+      - :ref:`Security aspects <security-overview>` • :ref:`Image retention policy <image-retention-policy>`  
 
 
 
@@ -53,9 +55,9 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides  <azure-how-to/index>` assume you have basic familiarity with Ubuntu images on Azure and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on Azure.
+* :ref:`How-to guides <azure-how-to-index>` assume you have basic familiarity with Ubuntu images on Azure and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on Azure.
 
-* :doc:`Explanation <azure-explanation/index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings, security features, package maintenance our image retention policy.
+* :ref:`Explanation <azure-explanation-index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings, security features, package maintenance our image retention policy.
 
 ---------
 
@@ -71,7 +73,7 @@ Get involved
 * `Join our online chat`_
 * `Discuss on Matrix`_
 * `Talk to us about Ubuntu on Azure`_
-* :doc:`azure-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 Governance and policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/google/google-explanation/canonical-offerings.rst
+++ b/docs/google/google-explanation/canonical-offerings.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Canonical's Ubuntu image offerings on GCP, including optimized kernels, GCE and GKE specific kernel variants, the rolling kernel model and Anthos offerings.
 
+.. _canonical-offerings:
+
 Canonical's offerings on GCP
 ============================
 
@@ -14,7 +16,7 @@ The Ubuntu images support secure boot, with signed NVIDIA drivers available for 
 
 Ubuntu images are updated regularly with fixes that address the latest CVEs to ensure applications remain free from vulnerabilities.
 
-Another useful feature is the native integration of Ubuntu images with the Administrator console, enabling patch management and :doc:`in-place upgrade of Ubuntu LTS images to Ubuntu Pro <../google-how-to/gce/upgrade-in-place-from-lts-to-pro>` without the need for workload redeployment.
+Another useful feature is the native integration of Ubuntu images with the Administrator console, enabling patch management and :ref:`in-place upgrade of Ubuntu LTS images to Ubuntu Pro <upgrade-in-place-from-lts-to-pro>` without the need for workload redeployment.
 
 
 

--- a/docs/google/google-explanation/gce-image-retention-policy.rst
+++ b/docs/google/google-explanation/gce-image-retention-policy.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand GCE Ubuntu image retention policies, including release, deprecation, and deletion stages for cloud images.
 
+.. _gce-image-retention-policy:
+
 GCE image retention policies
 =============================
 
@@ -18,7 +20,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`, and to get a list of these images on GCP, refer to: :doc:`../google-how-to/gce/find-ubuntu-images`.
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`, and to get a list of these images on GCP, refer to: :ref:`find-ubuntu-images`.
 
 The retention policy can be summarized as follows:
 

--- a/docs/google/google-explanation/gce-image-testing.rst
+++ b/docs/google/google-explanation/gce-image-testing.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand how Canonical tests Ubuntu GCE images before release, using its own internal test suite and Google's upstream cloud-image-tests.
 
+.. _gce-image-testing:
+
 Image testing
 =============
 
@@ -15,7 +17,7 @@ We run two sets of automated tests on each daily GCE image:
 Testing in the image life-cycle
 -------------------------------
 
-Ubuntu images on GCE move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :doc:`image release types <all-clouds:all-clouds-explanation/release-types>` and the :doc:`GCE image retention policy <gce-image-retention-policy>`.)
+Ubuntu images on GCE move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :ref:`image release types <all-clouds:release-types>` and the :ref:`GCE image retention policy <gce-image-retention-policy>`.)
 
 New images are built daily from the latest packages. Each daily build is uploaded and then exercised by the two sets of tests described below.
 
@@ -84,7 +86,7 @@ Image families and architectures
 
 The image families published for GCE (including Base, Minimal, Accelerator, TPU, Ubuntu Pro, Ubuntu Pro FIPS and Ubuntu Core) are each tested with the checks relevant to them. Tests run across the supported architectures (`amd64` and `arm64`), so both architectures of an image are validated before release.
 
-Coverage is tailored per family: for example, Pro images additionally validate Pro entitlements, accelerator images additionally validate GPU readiness, and Ubuntu Core images follow a dedicated test path suited to their image format. For more on the available families, see :doc:`Canonical's offerings on GCP <canonical-offerings>`.
+Coverage is tailored per family: for example, Pro images additionally validate Pro entitlements, accelerator images additionally validate GPU readiness, and Ubuntu Core images follow a dedicated test path suited to their image format. For more on the available families, see :ref:`Canonical's offerings on GCP <canonical-offerings>`.
 
 
 Test outcomes
@@ -92,7 +94,7 @@ Test outcomes
 
 Test outcomes determine whether a daily image can be promoted: if all tests pass, the build becomes eligible for promotion to a release image; if any test fails, the build is not promoted.
 
-The result of this process is that the Ubuntu images you launch from GCE have each passed both Canonical's own internal test suite and Google's upstream Cloud Image Tests for their family and architecture. For more on the security features validated along the way, see the :doc:`security overview <security-overview>`.
+The result of this process is that the Ubuntu images you launch from GCE have each passed both Canonical's own internal test suite and Google's upstream Cloud Image Tests for their family and architecture. For more on the security features validated along the way, see the :ref:`security overview <security-overview>`.
 
 
 .. _`cloud-image-tests`: https://github.com/GoogleCloudPlatform/cloud-image-tests

--- a/docs/google/google-explanation/guest-agents.rst
+++ b/docs/google/google-explanation/guest-agents.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover the different Google guest agents installed on Ubuntu GCP images - google-guest-agent, gce-compute-image-packages, google-compute-engine-oslogin and google-osconfig-agent.
 
+.. _guest-agents:
+
 Google agents installed on Ubuntu
 =================================
 

--- a/docs/google/google-explanation/index.rst
+++ b/docs/google/google-explanation/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Explanations of Ubuntu on GCP offerings, security, google guest agents, image testing, and image retention policies for cloud deployments.
 
+.. _google-explanation-index:
+
 Explanation
 ===========
 

--- a/docs/google/google-explanation/security-overview.rst
+++ b/docs/google/google-explanation/security-overview.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about the security features available with Ubuntu images on GCP, including confidential computing and Ubuntu Pro enhancements.
 
+.. _security-overview:
+
 Security features with Ubuntu on GCP
 ====================================
 
@@ -10,7 +12,7 @@ Ubuntu images on Google Cloud include the security features provided by both Ubu
 Ubuntu security features
 ------------------------
 
-Ubuntu on GCP provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on GCP provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 
 GCP security features
@@ -44,8 +46,8 @@ To find Ubuntu Pro images on GCE, refer to:
 
 For other Pro related operations such as, enabling features and performing an in-place upgrade, refer to:
 
-* :doc:`../google-how-to/gce/enable-pro-features`
-* :doc:`../google-how-to/gce/upgrade-in-place-from-lts-to-pro`
+* :ref:`enable-pro-features`
+* :ref:`upgrade-in-place-from-lts-to-pro`
 
 
 .. _`Ubuntu security page`: https://ubuntu.com/security

--- a/docs/google/google-how-to/contribute-to-these-docs.rst
+++ b/docs/google/google-how-to/contribute-to-these-docs.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to contribute to Ubuntu on Google Cloud documentation, including editing, building, and submitting pull requests.
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/google/google-how-to/gce/arm64-on-google-cloud.rst
+++ b/docs/google/google-how-to/gce/arm64-on-google-cloud.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to use the 64K page kernel on ARM64 instances on Google Cloud, including supported machine types and how to switch kernel variants.
 
+.. _arm64-on-google-cloud:
+
 Use 64K page kernel on ARM64 instances
 ======================================
 

--- a/docs/google/google-how-to/gce/build-ubuntu-pro-golden-image.rst
+++ b/docs/google/google-how-to/gce/build-ubuntu-pro-golden-image.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create an Ubuntu Pro golden image using GCP's Cloud Shell. Includes steps to share the image with other users and to create an instance using the image.
 
 
+.. _build-ubuntu-pro-golden-image:
+
 Build Ubuntu Pro golden image
 =============================
 

--- a/docs/google/google-how-to/gce/create-customized-docker-container.rst
+++ b/docs/google/google-how-to/gce/create-customized-docker-container.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create customized Docker containers on Ubuntu Pro. Includes steps to install Docker, pull an official Ubuntu image, run a container and customize it.
 
 
+.. _create-customized-docker-container:
+
 Create customized docker containers on Ubuntu Pro
 =================================================
 

--- a/docs/google/google-how-to/gce/create-different-instance-types.rst
+++ b/docs/google/google-how-to/gce/create-different-instance-types.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create different instance types on Google Cloud Platform. Includes steps to create Ubuntu LTS, Ubuntu Pro, Ubuntu Pro FIPS, ARM-based, confidential computing and GPU instances.
 
 
+.. _create-different-instance-types:
+
 Create different instance types on GCP
 ======================================
 

--- a/docs/google/google-how-to/gce/enable-pro-features.rst
+++ b/docs/google/google-how-to/gce/enable-pro-features.rst
@@ -2,6 +2,8 @@
    :description: Learn how to enable Ubuntu Pro features on GCE instances. Includes steps to enable ESM, CIS hardening, FIPS compliance and Livepatch on your Pro VM.
 
 
+.. _enable-pro-features:
+
 Enable Ubuntu Pro features
 ==========================
 
@@ -9,7 +11,7 @@ Not all Pro features are automatically enabled when you create your Ubuntu Pro V
 
 .. Note::
 
-    If you don't have an Ubuntu Pro VM already, you can either create a new instance (refer: :ref:`create-pro-on-gcp`) or do an in-place upgrade of your LTS VM to Pro (refer: :doc:`upgrade-in-place-from-lts-to-pro`).
+    If you don't have an Ubuntu Pro VM already, you can either create a new instance (refer: :ref:`create-pro-on-gcp`) or do an in-place upgrade of your LTS VM to Pro (refer: :ref:`upgrade-in-place-from-lts-to-pro`).
 
 
 To check the current status of different Pro services on your VM, SSH into it and run:

--- a/docs/google/google-how-to/gce/find-ubuntu-images.rst
+++ b/docs/google/google-how-to/gce/find-ubuntu-images.rst
@@ -2,6 +2,8 @@
    :description: Learn how to find Ubuntu images on GCE using the Google Cloud console or the gcloud command line tool. Includes a link to Canonical's Ubuntu cloud image finder for more filtering options.
 
 
+.. _find-ubuntu-images:
+
 Find Ubuntu images on GCE
 =========================
 

--- a/docs/google/google-how-to/gce/index.rst
+++ b/docs/google/google-how-to/gce/index.rst
@@ -2,6 +2,8 @@
    :description: List of how-to guides for launching, managing, and upgrading Ubuntu on GCE, including image selection and instance creation.
 
 
+.. _gce-index:
+
 Using GCE
 =========
 
@@ -9,25 +11,25 @@ These how-to guides relate to launching and using Ubuntu-based GCE instances. Th
 
 Launching different types of instances:
 
-* :doc:`Find images <find-ubuntu-images>`
-* :doc:`Create instances <create-different-instance-types>`
-* :doc:`Launch a desktop <launch-ubuntu-desktop>`
-* :doc:`Use 64K page kernel on ARM64 instances <arm64-on-google-cloud>`
+* :ref:`Find images <find-ubuntu-images>`
+* :ref:`Create instances <create-different-instance-types>`
+* :ref:`Launch a desktop <launch-ubuntu-desktop>`
+* :ref:`Use 64K page kernel on ARM64 instances <arm64-on-google-cloud>`
 
 Creating golden images and customized containers:
 
-* :doc:`Build a Pro golden image <build-ubuntu-pro-golden-image>`
-* :doc:`Create customized docker containers <create-customized-docker-container>`
+* :ref:`Build a Pro golden image <build-ubuntu-pro-golden-image>`
+* :ref:`Create customized docker containers <create-customized-docker-container>`
 
 Performing upgrades:
 
-* :doc:`Change license between LTS and Pro <upgrade-in-place-from-lts-to-pro>`
-* :doc:`Enable Pro features <enable-pro-features>`
-* :doc:`Upgrade from Focal to Jammy <upgrade-from-focal-to-jammy>`
+* :ref:`Change license between LTS and Pro <upgrade-in-place-from-lts-to-pro>`
+* :ref:`Enable Pro features <enable-pro-features>`
+* :ref:`Upgrade from Focal to Jammy <upgrade-from-focal-to-jammy>`
 
 Administrative operations:
 
-* :doc:`Set hostname <set-hostname-using-cloudinit>`
+* :ref:`Set hostname <set-hostname-using-cloudinit>`
 
 .. toctree::
    :hidden:

--- a/docs/google/google-how-to/gce/launch-ubuntu-desktop.rst
+++ b/docs/google/google-how-to/gce/launch-ubuntu-desktop.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to launch Ubuntu Desktop on GCE virtual machines. Includes steps to install Chrome Remote Desktop, set up a desktop environment and connect to it from your local machine.
 
+.. _launch-ubuntu-desktop:
+
 Launch an Ubuntu desktop on a VM
 ================================
 

--- a/docs/google/google-how-to/gce/set-hostname-using-cloudinit.rst
+++ b/docs/google/google-how-to/gce/set-hostname-using-cloudinit.rst
@@ -2,6 +2,8 @@
    :description: Learn how to set hostname of GCE instances using Google's DHCP service or using cloud-init. Includes details about changes needed for Ubuntu 24.04 LTS and later images.
 
 
+.. _set-hostname-using-cloudinit:
+
 Set hostname of GCE instances
 =============================
 

--- a/docs/google/google-how-to/gce/upgrade-from-focal-to-jammy.rst
+++ b/docs/google/google-how-to/gce/upgrade-from-focal-to-jammy.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to upgrade Ubuntu from 20.04 LTS (Focal) to 22.04 LTS (Jammy) on GCE. Includes detailed steps for performing an in-place upgrade using do-release-upgrade.
 
+.. _upgrade-from-focal-to-jammy:
+
 Upgrade from Focal to Jammy on GCE
 ==================================
 

--- a/docs/google/google-how-to/gce/upgrade-in-place-from-lts-to-pro.rst
+++ b/docs/google/google-how-to/gce/upgrade-in-place-from-lts-to-pro.rst
@@ -2,6 +2,8 @@
    :description: Learn how to switch between Ubuntu LTS and Ubuntu Pro in-place on GCE. Includes steps to update the license and verify the changes.
 
 
+.. _upgrade-in-place-from-lts-to-pro:
+
 Change license between LTS and Pro
 ====================================
 

--- a/docs/google/google-how-to/gke/create-gke-cluster-with-ubuntu-nodes.rst
+++ b/docs/google/google-how-to/gke/create-gke-cluster-with-ubuntu-nodes.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create a Google Kubernetes Engine (GKE) cluster with Ubuntu nodes using the gcloud CLI, and verify the node OS image.
 
 
+.. _create-gke-cluster-with-ubuntu-nodes:
+
 Create a GKE cluster with Ubuntu nodes
 ======================================
 

--- a/docs/google/google-how-to/gke/deploy-kubernetes-with-ubuntu-pro.rst
+++ b/docs/google/google-how-to/gke/deploy-kubernetes-with-ubuntu-pro.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy Kubernetes with Ubuntu Pro on Google Cloud. Includes steps to create Ubuntu Pro VMs, install Kubernetes using MicroK8s, create a cluster and access it.
 
 
+.. _deploy-kubernetes-with-ubuntu-pro:
+
 Deploy Kubernetes with Ubuntu Pro on GCE
 ========================================
 

--- a/docs/google/google-how-to/gke/index.rst
+++ b/docs/google/google-how-to/gke/index.rst
@@ -2,13 +2,15 @@
    :description: List of how-to guides related to Google Kubernetes Engine (GKE). Learn how to create a kubernetes cluster using Ubuntu Pro and how to install Charmed Kubeflow on GKE.
 
 
+.. _gke-index:
+
 Using Kubernetes
 ================
 
 If you want to create a GKE cluster with Ubuntu nodes, use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kubeflow on GKE, you can use these how-to guides.
 
-* :doc:`Create a GKE cluster with Ubuntu nodes <create-gke-cluster-with-ubuntu-nodes>`
-* :doc:`Deploy Ubuntu Pro based k8s on GCE <deploy-kubernetes-with-ubuntu-pro>`
+* :ref:`Create a GKE cluster with Ubuntu nodes <create-gke-cluster-with-ubuntu-nodes>`
+* :ref:`Deploy Ubuntu Pro based k8s on GCE <deploy-kubernetes-with-ubuntu-pro>`
 * `Install Charmed Kubeflow on GKE`_
 
    

--- a/docs/google/google-how-to/index.rst
+++ b/docs/google/google-how-to/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: List of how-to guides for launching, managing, and upgrading Ubuntu on Google Cloud, including image selection and solution deployment.
    
+.. _google-how-to-index:
+
 How-to guides
 =============
 
@@ -11,24 +13,24 @@ GCE - Launching and using Ubuntu instances
 
 While using Ubuntu on GCP, you'll need to perform tasks such as finding the right image to use, launching different instance types, creating golden images and containers, using Ubuntu Pro and doing upgrades.
 
-* :doc:`Find images <gce/find-ubuntu-images>`
-* :doc:`Create instances <gce/create-different-instance-types>`
-* :doc:`Launch a desktop <gce/launch-ubuntu-desktop>`
-* :doc:`Build a Pro golden image <gce/build-ubuntu-pro-golden-image>`
-* :doc:`Create customized docker containers <gce/create-customized-docker-container>`
-* :doc:`Change license between LTS and Pro <gce/upgrade-in-place-from-lts-to-pro>`
-* :doc:`Enable Pro features <gce/enable-pro-features>`
-* :doc:`Upgrade from Focal to Jammy <gce/upgrade-from-focal-to-jammy>`
-* :doc:`Set hostname <gce/set-hostname-using-cloudinit>`
-* :doc:`Use 64K page kernel on ARM64 instances <gce/arm64-on-google-cloud>`
+* :ref:`Find images <find-ubuntu-images>`
+* :ref:`Create instances <create-different-instance-types>`
+* :ref:`Launch a desktop <launch-ubuntu-desktop>`
+* :ref:`Build a Pro golden image <build-ubuntu-pro-golden-image>`
+* :ref:`Create customized docker containers <create-customized-docker-container>`
+* :ref:`Change license between LTS and Pro <upgrade-in-place-from-lts-to-pro>`
+* :ref:`Enable Pro features <enable-pro-features>`
+* :ref:`Upgrade from Focal to Jammy <upgrade-from-focal-to-jammy>`
+* :ref:`Set hostname <set-hostname-using-cloudinit>`
+* :ref:`Use 64K page kernel on ARM64 instances <arm64-on-google-cloud>`
 
 GKE and Kubernetes
 ------------------
 
 If you want to create a GKE cluster with Ubuntu nodes, use Ubuntu Pro on your Kubernetes cluster, or install Charmed Kubeflow on GKE, you can use these instructions.
 
-* :doc:`Create a GKE cluster with Ubuntu nodes <gke/create-gke-cluster-with-ubuntu-nodes>`
-* :doc:`Deploy Ubuntu Pro based k8s on GCE <gke/deploy-kubernetes-with-ubuntu-pro>`
+* :ref:`Create a GKE cluster with Ubuntu nodes <create-gke-cluster-with-ubuntu-nodes>`
+* :ref:`Deploy Ubuntu Pro based k8s on GCE <deploy-kubernetes-with-ubuntu-pro>`
 * `Install Charmed Kubeflow on GKE`_
 
    

--- a/docs/google/index.rst
+++ b/docs/google/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover Ubuntu on Google Cloud Platform (GCP), including optimized images, deployment guides, and best practices for cloud workloads.
 
+.. _index:
+
 Ubuntu on GCP
 =============
 
@@ -26,22 +28,22 @@ In this documentation
     :header-rows: 0
 
     * - **Canonical's offerings**
-      - :doc:`GCP optimizations <google-explanation/canonical-offerings>` • :doc:`Packaged Google agents <google-explanation/guest-agents>` 
+      - :ref:`GCP optimizations <canonical-offerings>` • :ref:`Packaged Google agents <guest-agents>` 
       
     * - **Finding and launching images**
-      - :doc:`Find images <google-how-to/gce/find-ubuntu-images>` • :doc:`Create instances <google-how-to/gce/create-different-instance-types>` • :doc:`Launch a desktop <google-how-to/gce/launch-ubuntu-desktop>` • :doc:`Use 64K page kernel on ARM64 instances <google-how-to/gce/arm64-on-google-cloud>`
+      - :ref:`Find images <find-ubuntu-images>` • :ref:`Create instances <create-different-instance-types>` • :ref:`Launch a desktop <launch-ubuntu-desktop>` • :ref:`Use 64K page kernel on ARM64 instances <arm64-on-google-cloud>`
       
     * - **Upgrades and maintenance**
-      - :doc:`Switch between LTS and Pro <google-how-to/gce/upgrade-in-place-from-lts-to-pro>` • :doc:`Enable Ubuntu Pro features <google-how-to/gce/enable-pro-features>` • :doc:`Upgrade from Focal to Jammy <google-how-to/gce/upgrade-from-focal-to-jammy>` 
+      - :ref:`Switch between LTS and Pro <upgrade-in-place-from-lts-to-pro>` • :ref:`Enable Ubuntu Pro features <enable-pro-features>` • :ref:`Upgrade from Focal to Jammy <upgrade-from-focal-to-jammy>` 
 
     * - **Creating golden images**
-      - :doc:`Build a Pro golden image <google-how-to/gce/build-ubuntu-pro-golden-image>`
+      - :ref:`Build a Pro golden image <build-ubuntu-pro-golden-image>`
             
     * - **Custom deployments**
-      - :doc:`Create a GKE cluster with Ubuntu nodes <google-how-to/gke/create-gke-cluster-with-ubuntu-nodes>` • :doc:`Deploy Kubernetes with Ubuntu Pro on GCE <google-how-to/gke/deploy-kubernetes-with-ubuntu-pro>` • :doc:`Create customized docker containers <google-how-to/gce/create-customized-docker-container>` • :doc:`Set hostname <google-how-to/gce/set-hostname-using-cloudinit>` 
+      - :ref:`Create a GKE cluster with Ubuntu nodes <create-gke-cluster-with-ubuntu-nodes>` • :ref:`Deploy Kubernetes with Ubuntu Pro on GCE <deploy-kubernetes-with-ubuntu-pro>` • :ref:`Create customized docker containers <create-customized-docker-container>` • :ref:`Set hostname <set-hostname-using-cloudinit>` 
       
     * - **Quality and policies**
-      - :doc:`Security aspects <google-explanation/security-overview>` • :doc:`Image testing <google-explanation/gce-image-testing>` • :doc:`Image retention policy <google-explanation/gce-image-retention-policy>`
+      - :ref:`Security aspects <security-overview>` • :ref:`Image testing <gce-image-testing>` • :ref:`Image retention policy <gce-image-retention-policy>`
 
 
 
@@ -51,9 +53,9 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides  <google-how-to/index>` assume you have basic familiarity with Ubuntu images on GCP and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on GCP.
+* :ref:`How-to guides <google-how-to-index>` assume you have basic familiarity with Ubuntu images on GCP and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on GCP.
 
-* :doc:`Explanation <google-explanation/index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings, security features, Google's 'guest agents' on Ubuntu and our image retention policy.
+* :ref:`Explanation <google-explanation-index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings, security features, Google's 'guest agents' on Ubuntu and our image retention policy.
 
 ---------
 
@@ -69,7 +71,7 @@ Get involved
 * `Join our online chat`_
 * `Discuss on Matrix`_
 * `Talk to us about Ubuntu on Google cloud`_
-* :doc:`google-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 Governance and policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ibm/ibm-explanation/canonical-offerings.rst
+++ b/docs/ibm/ibm-explanation/canonical-offerings.rst
@@ -2,6 +2,8 @@
    :description: Learn about Canonical's Ubuntu image offerings on IBM Cloud, including a custom kernel, Ubuntu Pro and support options from Canonical and the community.
 
 
+.. _canonical-offerings:
+
 Canonical's offerings on IBM Cloud
 ===================================
 

--- a/docs/ibm/ibm-explanation/index.rst
+++ b/docs/ibm/ibm-explanation/index.rst
@@ -2,6 +2,8 @@
    :description: Explanations about Canonical's offerings on IBM Cloud and the available security features.
 
 
+.. _ibm-explanation-index:
+
 Explanation
 ===========
 

--- a/docs/ibm/ibm-explanation/security-overview.rst
+++ b/docs/ibm/ibm-explanation/security-overview.rst
@@ -2,6 +2,8 @@
    :description: Understand the Ubuntu and IBM security features available while using Ubuntu on IBM Cloud.
 
 
+.. _security-overview:
+
 Security features with Ubuntu on IBM Cloud
 ==========================================
 
@@ -10,7 +12,7 @@ Ubuntu images on IBM Cloud include the security features provided by both Ubuntu
 Ubuntu security features
 ------------------------
 
-Ubuntu on IBM provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on IBM provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 
 IBM Cloud security features

--- a/docs/ibm/ibm-how-to/contribute-to-these-docs.rst
+++ b/docs/ibm/ibm-how-to/contribute-to-these-docs.rst
@@ -2,6 +2,8 @@
    :description: Learn how to contribute to Ubuntu on IBM Cloud documentation, including editing, building, and submitting pull requests.
 
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/ibm/ibm-how-to/find-ubuntu-images.rst
+++ b/docs/ibm/ibm-how-to/find-ubuntu-images.rst
@@ -2,6 +2,8 @@
    :description: Learn how to find Ubuntu images on IBM Cloud. Includes instructions for using the web console and the CLI for both IBM VPC and Classic infrastructures.
 
 
+.. _find-ubuntu-images:
+
 Find Ubuntu images on IBM Cloud
 ===============================
 

--- a/docs/ibm/ibm-how-to/index.rst
+++ b/docs/ibm/ibm-how-to/index.rst
@@ -1,16 +1,18 @@
 .. meta::
    :description: List of how-to guides for finding, launching and upgrading Ubuntu images on IBM Cloud.
 
+.. _ibm-how-to-index:
+
 How-to guides
 =============
 
 These guides provide instructions for using Ubuntu images on IBM Cloud. They include operations such as finding images, launching an Ubuntu instance, and upgrading from one version of Ubuntu to another.
 
 
-* :doc:`Find Ubuntu images on IBM Cloud<find-ubuntu-images>`
-* :doc:`Launch an Ubuntu instance on IBM Cloud<launch-ubuntu-instances>`
-* :doc:`Upgrade from Ubuntu 20.04 LTS to Ubuntu 22.04 LTS<upgrade-from-focal-to-jammy>`
-* :doc:`Upgrade from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS<upgrade-from-jammy-to-noble>`
+* :ref:`Find Ubuntu images on IBM Cloud <find-ubuntu-images>`
+* :ref:`Launch an Ubuntu instance on IBM Cloud <launch-ubuntu-instances>`
+* :ref:`Upgrade from Ubuntu 20.04 LTS to Ubuntu 22.04 LTS <upgrade-from-focal-to-jammy>`
+* :ref:`Upgrade from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS <upgrade-from-jammy-to-noble>`
    
 .. toctree::
    :hidden:

--- a/docs/ibm/ibm-how-to/launch-ubuntu-instances.rst
+++ b/docs/ibm/ibm-how-to/launch-ubuntu-instances.rst
@@ -2,6 +2,8 @@
    :description: Learn how to launch Ubuntu VSI instances on IBM Cloud using the web console or the CLI. 
 
 
+.. _launch-ubuntu-instances:
+
 Launch an Ubuntu VSI on IBM Cloud
 =================================
 
@@ -57,7 +59,7 @@ SSH key pairs are needed to log in to a VSI from your local machine. To create o
 Find an Ubuntu image
 ~~~~~~~~~~~~~~~~~~~~
 
-Use :doc:`Find Ubuntu images <find-ubuntu-images>` to find an appropriate Ubuntu image and its ID.
+Use :ref:`Find Ubuntu images <find-ubuntu-images>` to find an appropriate Ubuntu image and its ID.
 
 
 Choose a zone and region

--- a/docs/ibm/ibm-how-to/upgrade-from-focal-to-jammy.rst
+++ b/docs/ibm/ibm-how-to/upgrade-from-focal-to-jammy.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to upgrade Ubuntu from 20.04 (Focal) to 22.04 (Jammy) on IBM Cloud. 
 
+.. _upgrade-from-focal-to-jammy:
+
 Upgrade from Focal to Jammy on IBM Cloud
 ========================================
 

--- a/docs/ibm/ibm-how-to/upgrade-from-jammy-to-noble.rst
+++ b/docs/ibm/ibm-how-to/upgrade-from-jammy-to-noble.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to upgrade Ubuntu from 22.04 (Jammy) to 24.04 (Noble) on IBM Cloud. 
    
+.. _upgrade-from-jammy-to-noble:
+
 Upgrade from Jammy to Noble on IBM Cloud
 ========================================
 

--- a/docs/ibm/index.rst
+++ b/docs/ibm/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover Ubuntu on IBM Cloud, including optimized images, deployment guides, and best practices for cloud workloads.
 
+.. _index:
+
 Ubuntu on IBM
 =============
 
@@ -27,13 +29,13 @@ In this documentation
     :header-rows: 0
 
     * - **Canonical's offerings**
-      - :doc:`IBM optimizations <ibm-explanation/canonical-offerings>` • :doc:`Security overview <ibm-explanation/security-overview>` 
+      - :ref:`IBM optimizations <canonical-offerings>` • :ref:`Security overview <security-overview>` 
       
     * - **Finding and launching images**
-      - :doc:`Find images <ibm-how-to/find-ubuntu-images>` • :doc:`Launch an Ubuntu VSI <ibm-how-to/launch-ubuntu-instances>` 
+      - :ref:`Find images <find-ubuntu-images>` • :ref:`Launch an Ubuntu VSI <launch-ubuntu-instances>` 
 
     * - **Upgrades and maintenance**
-      - :doc:`Upgrade from Ubuntu 20.04 to 22.04 <ibm-how-to/upgrade-from-focal-to-jammy>` • :doc:`Upgrade from Ubuntu 22.04 to 24.04 <ibm-how-to/upgrade-from-jammy-to-noble>` 
+      - :ref:`Upgrade from Ubuntu 20.04 to 22.04 <upgrade-from-focal-to-jammy>` • :ref:`Upgrade from Ubuntu 22.04 to 24.04 <upgrade-from-jammy-to-noble>` 
 
 
 How this documentation is organized
@@ -42,9 +44,9 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides  <ibm-how-to/index>` assume you have basic familiarity with Ubuntu images on IBM Cloud and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on IBM Cloud.
+* :ref:`How-to guides <ibm-how-to-index>` assume you have basic familiarity with Ubuntu images on IBM Cloud and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu on IBM Cloud.
 
-* :doc:`Explanation <ibm-explanation/index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings on IBM Cloud and an overview of available security features.
+* :ref:`Explanation <ibm-explanation-index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings on IBM Cloud and an overview of available security features.
 
 ---------
 
@@ -61,7 +63,7 @@ Get involved
 * `Join our online chat`_
 * `Discuss on Matrix`_
 * `Talk to us about Ubuntu on IBM`_
-* :doc:`ibm-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 Governance and policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/oci/index.rst
+++ b/docs/oci/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about Ubuntu container images on OCI registries, including security, multi-arch support, and trusted application base images.
 
+.. _index:
+
 Ubuntu on OCI container registries
 ==================================
 
@@ -23,13 +25,13 @@ In this documentation
 
 
     * - **Tutorial**
-      - :doc:`Create an Ubuntu FIPS Docker image <oci-tutorials/fips-ubuntu-container>`
+      - :ref:`Create an Ubuntu FIPS Docker image <how-to-fips-ubuntu-container>`
 
     * - **Canonical's offerings**
-      - :doc:`Ubuntu OCI container images <oci-explanation/ubuntu-oci-container>` • :doc:`Ubuntu Pro OCI container images <oci-explanation/ubuntu-pro-oci-container>` • :doc:`OCI image configuration <oci-reference/oci-image-configuration>` 
+      - :ref:`Ubuntu OCI container images <ubuntu-oci-container-images>` • :ref:`Ubuntu Pro OCI container images <ubuntu-pro-oci-container-images>` • :ref:`OCI image configuration <oci-image-configuration>` 
 
     * - **Working with Ubuntu OCI containers**
-      - :doc:`Find the Ubuntu container images <oci-how-to/getting-started>` • :doc:`Deploy Ubuntu Pro containers on Kubernetes <oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster>`
+      - :ref:`Find the Ubuntu container images <getting-started>` • :ref:`Deploy Ubuntu Pro containers on Kubernetes <how-to-deploy-pro-container-on-pro-cluster>`
       
 
 How this documentation is organized
@@ -38,13 +40,13 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* The :doc:`Tutorial <oci-tutorials/fips-ubuntu-container>` takes you step-by-step through the basics of creating an Ubuntu FIPS Docker image.
+* The :ref:`Tutorial <how-to-fips-ubuntu-container>` takes you step-by-step through the basics of creating an Ubuntu FIPS Docker image.
 
-* :doc:`How-to guides  <oci-how-to/index>` assume you have basic familiarity with Ubuntu images on OCI container registries and want to achieve specific goals. They are instructions for finding Ubuntu container images and deploying Ubuntu Pro containers on Kubernetes clusters.
+* :ref:`How-to guides <oci-how-to>` assume you have basic familiarity with Ubuntu images on OCI container registries and want to achieve specific goals. They are instructions for finding Ubuntu container images and deploying Ubuntu Pro containers on Kubernetes clusters.
 
-* :doc:`Reference <oci-reference/index>` includes an in-depth description of the Ubuntu image's OCI configuration.
+* :ref:`Reference <oci-reference>` includes an in-depth description of the Ubuntu image's OCI configuration.
 
-* :doc:`Explanation <oci-explanation/index>` includes definitions of the Ubuntu and Ubuntu Pro container images.
+* :ref:`Explanation <oci-explanation-index>` includes definitions of the Ubuntu and Ubuntu Pro container images.
 
 ---------
 

--- a/docs/oci/oci-explanation/index.rst
+++ b/docs/oci/oci-explanation/index.rst
@@ -3,6 +3,8 @@
 
 .. _oci-explanation:
 
+.. _oci-explanation-index:
+
 ***********
 Explanation
 ***********

--- a/docs/oci/oci-how-to/contribute-to-these-docs.rst
+++ b/docs/oci/oci-how-to/contribute-to-these-docs.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to contribute to Ubuntu on OCI container registry documentation, including editing, building, and submitting pull requests.
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/oci/oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster.rst
+++ b/docs/oci/oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster.rst
@@ -28,12 +28,12 @@ Deploying Pro Kubernetes clusters in various clouds
 
 	.. tab:: EKS
 
-		Check out :doc:`aws:aws-how-to/kubernetes/deploy-ubuntu-pro-cluster` to learn
+		Check out :ref:`aws:deploy-ubuntu-pro-cluster` to learn
 		how to deploy an Ubuntu Pro Kubernetes cluster on Elastic Kubernetes Service (EKS).
 
 	.. tab:: GCE
 
-		Check out :doc:`google:google-how-to/gke/deploy-kubernetes-with-ubuntu-pro` to learn
+		Check out :ref:`google:deploy-kubernetes-with-ubuntu-pro` to learn
 		how to deploy an Ubuntu Pro Kubernetes cluster on Google Compute Engine (GCE).
 
 	.. tab:: OpenShift

--- a/docs/oci/oci-how-to/getting-started.rst
+++ b/docs/oci/oci-how-to/getting-started.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to get started with Ubuntu container images on Docker Hub, Amazon ECR, Microsoft ACR, and IronBank.
 
+.. _getting-started:
+
 Getting started
 ***************
 

--- a/docs/oci/oci-reference/oci-image-configuration.rst
+++ b/docs/oci/oci-reference/oci-image-configuration.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: In-depth explanation of Ubuntu OCI image configuration, layers, and multi-architecture support for container deployments.
 
+.. _oci-image-configuration:
+
 Ubuntu OCI image configuration
 ******************************
 

--- a/docs/oracle/index.rst
+++ b/docs/oracle/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover Ubuntu on Oracle Cloud, including optimized images, deployment guides, and best practices for cloud workloads.
    
+.. _index:
+
 Ubuntu on Oracle
 ================
 
@@ -26,19 +28,19 @@ In this documentation
     :header-rows: 0
 
     * - **Canonical's offerings**
-      - :doc:`Oracle optimizations <oracle-explanation/canonical-offerings>` • :doc:`Security overview <oracle-explanation/security-overview>` 
+      - :ref:`Oracle optimizations <canonical-offerings>` • :ref:`Security overview <security-overview>` 
       
     * - **Finding and launching images**
-      - :doc:`Find images <oracle-how-to/find-ubuntu-images>` • :doc:`Use a bastion to access <oracle-how-to/use-bastion-to-access-VM>` 
+      - :ref:`Find images <find-ubuntu-images>` • :ref:`Use a bastion to access <use-bastion-to-access-VM>` 
       
     * - **Upgrades and maintenance**
-      - :doc:`Upgrade from Ubuntu 20.04 to 22.04 <oracle-how-to/upgrade-from-focal-to-jammy>` • :doc:`Upgrade from Ubuntu 22.04 to 24.04 <oracle-how-to/upgrade-from-jammy-to-noble>`
+      - :ref:`Upgrade from Ubuntu 20.04 to 22.04 <upgrade-from-focal-to-jammy>` • :ref:`Upgrade from Ubuntu 22.04 to 24.04 <upgrade-from-jammy-to-noble>`
       
     * - **Deploying Ubuntu OKE worker nodes**
-      - :doc:`Availability details <oracle-reference/ubuntu-availability-on-oke>` • :doc:`Deploy using Oracle Cloud Console <oracle-how-to/deploy-ubuntu-oke-nodes-using-console>` • :doc:`Deploy using CLI <oracle-how-to/deploy-ubuntu-oke-nodes-using-cli>` • :doc:`Deploy using Terraform <oracle-how-to/deploy-ubuntu-oke-nodes-using-terraform>` 
+      - :ref:`Availability details <ubuntu-availability-on-oke>` • :ref:`Deploy using Oracle Cloud Console <deploy-ubuntu-oke-nodes-using-console>` • :ref:`Deploy using CLI <deploy-ubuntu-oke-nodes-using-cli>` • :ref:`Deploy using Terraform <deploy-ubuntu-oke-nodes-using-terraform>` 
 
     * - **Custom deployments**
-      - :doc:`Use full-disk encryption <oracle-how-to/use-fde>` • :doc:`Enable confidential computing <oracle-how-to/enable-confidential-computing>` 
+      - :ref:`Use full-disk encryption <use-fde>` • :ref:`Enable confidential computing <enable-confidential-computing>` 
 
    
 
@@ -48,9 +50,9 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides  <oracle-how-to/index>` assume you have basic familiarity with Ubuntu images on Oracle Cloud and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu images on Oracle Cloud.
+* :ref:`How-to guides <oracle-how-to-index>` assume you have basic familiarity with Ubuntu images on Oracle Cloud and want to achieve specific goals. They are instructions covering key operations and common tasks involving the use of Ubuntu images on Oracle Cloud.
 
-* :doc:`Explanation <oracle-explanation/index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings on Oracle Cloud, Ubuntu on OKE nodes and an overview of available security features. 
+* :ref:`Explanation <oracle-explanation-index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as our offerings on Oracle Cloud, Ubuntu on OKE nodes and an overview of available security features. 
 
 
 ---------
@@ -67,7 +69,7 @@ Get involved
 * `Get support`_
 * `Join our online chat`_
 * `Discuss on Matrix`_
-* :doc:`oracle-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 Governance and policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/oracle/oracle-explanation/canonical-offerings.rst
+++ b/docs/oracle/oracle-explanation/canonical-offerings.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description:  Learn about Canonical's Ubuntu image offerings on Oracle Cloud, including a custom kernel, and two image types - server and minimal.
 
+.. _canonical-offerings:
+
 Canonical's offerings on Oracle Cloud
 =====================================
 
@@ -19,9 +21,9 @@ The images are built regularly and follow a thorough test framework that helps d
 
 With a single image type that is validated to work on both virtual machines and bare metal instances, the images aim to provide a consistent experience for users.
 
-Ubuntu images on Oracle Cloud also support confidential computing on AMD EPYC™ shapes (E3, E4, and E5). This provides hardware-level memory encryption using AMD SEV for VMs and AMD TSME for bare metal instances. For details on enabling this feature, refer to :doc:`../oracle-how-to/enable-confidential-computing`.
+Ubuntu images on Oracle Cloud also support confidential computing on AMD EPYC™ shapes (E3, E4, and E5). This provides hardware-level memory encryption using AMD SEV for VMs and AMD TSME for bare metal instances. For details on enabling this feature, refer to :ref:`enable-confidential-computing`.
 
-For instructions on how to find the images, refer to :doc:`../oracle-how-to/find-ubuntu-images`.
+For instructions on how to find the images, refer to :ref:`find-ubuntu-images`.
 
 
 Optimizations for Oracle Cloud

--- a/docs/oracle/oracle-explanation/index.rst
+++ b/docs/oracle/oracle-explanation/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Explanations about Canonical's offerings on Oracle Cloud, including OKE and the available security features.
 
+.. _oracle-explanation-index:
+
 Explanation
 ===========
 

--- a/docs/oracle/oracle-explanation/security-overview.rst
+++ b/docs/oracle/oracle-explanation/security-overview.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Understand the Ubuntu and Oracle Cloud security features available while using Ubuntu on Oracle Cloud, including full-disk encryption.
 
+.. _security-overview:
+
 Security features with Ubuntu on Oracle Cloud
 =============================================
 
@@ -9,7 +11,7 @@ Ubuntu images on Oracle Cloud include the security features provided by both Ubu
 Ubuntu security features
 ------------------------
 
-Ubuntu on Oracle provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on Oracle provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 
 Oracle Cloud security features
@@ -21,7 +23,7 @@ Oracle Cloud offers comprehensive security and data protection in the cloud. Thi
 Full-disk encryption (FDE)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FDE ensures that all data on the disk is inaccessible without an encryption key. To use FDE on Oracle Cloud, refer to :doc:`../oracle-how-to/use-fde`.
+FDE ensures that all data on the disk is inaccessible without an encryption key. To use FDE on Oracle Cloud, refer to :ref:`use-fde`.
 
 
 Confidential computing
@@ -32,7 +34,7 @@ Confidential computing protects data in-use by performing computation in a hardw
 * **AMD SEV** (Secure Encrypted Virtualization) on VM shapes — encrypts VM memory with a unique key per VM, isolating guests from the hypervisor.
 * **AMD TSME** (Transparent Secure Memory Encryption) on bare metal shapes — encrypts all system memory transparently.
 
-These technologies are available on E3, E4, and E5 shapes across select regions. For further details about AMD SEV and TSME, see `AMD's description of SEV`_. To enable confidential computing on an Oracle Cloud instance, refer to :doc:`../oracle-how-to/enable-confidential-computing`.
+These technologies are available on E3, E4, and E5 shapes across select regions. For further details about AMD SEV and TSME, see `AMD's description of SEV`_. To enable confidential computing on an Oracle Cloud instance, refer to :ref:`enable-confidential-computing`.
 
 
 .. _`Ubuntu security page`: https://ubuntu.com/security

--- a/docs/oracle/oracle-explanation/ubuntu-on-oke-worker-nodes.rst
+++ b/docs/oracle/oracle-explanation/ubuntu-on-oke-worker-nodes.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about using Ubuntu on OKE worker nodes, including supported configurations, deployment options and update management.
 
+.. _ubuntu-on-oke-worker-nodes:
+
 Ubuntu on OKE worker nodes
 ==========================
 
@@ -10,7 +12,7 @@ Ubuntu images are now available for worker nodes on Oracle Kubernetes Engine (OK
 Supported OKE configurations
 ----------------------------
 
-Currently there are only a select number of suites and Kubernetes versions supported due to this being a Limited Availability release. For a list of supported OKE configurations, see our :doc:`Ubuntu availability on OKE </oracle-reference/ubuntu-availability-on-oke>` page.
+Currently there are only a select number of suites and Kubernetes versions supported due to this being a Limited Availability release. For a list of supported OKE configurations, see our :ref:`Ubuntu availability on OKE <ubuntu-availability-on-oke>` page.
 
 
 Deployment options
@@ -18,9 +20,9 @@ Deployment options
 
 To deploy an Ubuntu worker node on OKE, you can use the Oracle Cloud Console, Oracle CLI (``oci``), or Terraform. For detailed instructions, refer to:
 
-- :doc:`Deploying Ubuntu worker nodes using the Oracle Cloud Console </oracle-how-to/deploy-ubuntu-oke-nodes-using-console>`
-- :doc:`Deploying Ubuntu worker nodes using the CLI </oracle-how-to/deploy-ubuntu-oke-nodes-using-cli>`
-- :doc:`Deploying Ubuntu worker nodes using Terraform </oracle-how-to/deploy-ubuntu-oke-nodes-using-terraform>`
+- :ref:`Deploying Ubuntu worker nodes using the Oracle Cloud Console <deploy-ubuntu-oke-nodes-using-console>`
+- :ref:`Deploying Ubuntu worker nodes using the CLI <deploy-ubuntu-oke-nodes-using-cli>`
+- :ref:`Deploying Ubuntu worker nodes using Terraform <deploy-ubuntu-oke-nodes-using-terraform>`
 
 
 Updates and security patches

--- a/docs/oracle/oracle-how-to/contribute-to-these-docs.rst
+++ b/docs/oracle/oracle-how-to/contribute-to-these-docs.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to contribute to Ubuntu on Oracle Cloud documentation, including editing, building, and submitting pull requests.
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/oracle/oracle-how-to/deploy-ubuntu-oke-nodes-using-cli.rst
+++ b/docs/oracle/oracle-how-to/deploy-ubuntu-oke-nodes-using-cli.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to deploy Ubuntu OKE nodes using CLI, including the creation of network resources, OKE cluster, and managed or self-managed node pools.
 
+.. _deploy-ubuntu-oke-nodes-using-cli:
+
 Deploy Ubuntu OKE nodes using CLI
 =================================
 

--- a/docs/oracle/oracle-how-to/deploy-ubuntu-oke-nodes-using-console.rst
+++ b/docs/oracle/oracle-how-to/deploy-ubuntu-oke-nodes-using-console.rst
@@ -1,12 +1,14 @@
 .. meta::
    :description: Learn how to deploy Ubuntu OKE nodes using Oracle Cloud Console, including cluster creation and node pool management.
 
+.. _deploy-ubuntu-oke-nodes-using-console:
+
 Deploy Ubuntu OKE nodes using Oracle Cloud Console
 ==================================================
 
 .. Introduction to Ubuntu OKE node
 
-Ubuntu images are available for OKE worker nodes, with support for a select number of suites and Kubernetes versions. For a list of supported OKE configurations, see our :doc:`Ubuntu availability on OKE </oracle-reference/ubuntu-availability-on-oke>` page.
+Ubuntu images are available for OKE worker nodes, with support for a select number of suites and Kubernetes versions. For a list of supported OKE configurations, see our :ref:`Ubuntu availability on OKE <ubuntu-availability-on-oke>` page.
 
 
 Prerequisites

--- a/docs/oracle/oracle-how-to/deploy-ubuntu-oke-nodes-using-terraform.rst
+++ b/docs/oracle/oracle-how-to/deploy-ubuntu-oke-nodes-using-terraform.rst
@@ -2,6 +2,8 @@
    :description: Learn how to deploy Ubuntu OKE nodes using Terraform, including the creation of an OKE cluster, and adding nodes.
 
 
+.. _deploy-ubuntu-oke-nodes-using-terraform:
+
 Deploy Ubuntu OKE nodes using Terraform
 =======================================
 

--- a/docs/oracle/oracle-how-to/enable-confidential-computing.rst
+++ b/docs/oracle/oracle-how-to/enable-confidential-computing.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create an instance with confidential computing enabled on Oracle Cloud, including supported shapes, regions, and limitations.
 
 
+.. _enable-confidential-computing:
+
 Enable confidential computing
 =============================
 
@@ -142,7 +144,7 @@ For more information about creating confidential computing enabled instances, re
 * `Protect data in use with OCI confidential computing <https://blogs.oracle.com/cloud-infrastructure/protect-data-in-use-with-confidential-computing>`_
 * `Confidential computing <https://docs.oracle.com/en-us/iaas/Content/Compute/References/confidential_compute.htm>`_
 
-For a general overview of confidential computing technologies, see :doc:`all-clouds:all-clouds-explanation/confidential-computing`.
+For a general overview of confidential computing technologies, see :ref:`all-clouds:confidential-computing`.
 
 .. _`AMD documentation`: https://www.amd.com/en/developer/sev.html
 .. _`Shapes that support confidential computing`: https://docs.oracle.com/en-us/iaas/Content/Compute/References/confidential_compute.htm#confidential_compute__coco_supported_shapes

--- a/docs/oracle/oracle-how-to/find-ubuntu-images.rst
+++ b/docs/oracle/oracle-how-to/find-ubuntu-images.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to find Ubuntu images on Oracle Cloud using the web console and CLI, and also to find images for OKE worker nodes. 
 
+.. _find-ubuntu-images:
+
 Find Ubuntu images on Oracle Cloud 
 ==================================
 

--- a/docs/oracle/oracle-how-to/index.rst
+++ b/docs/oracle/oracle-how-to/index.rst
@@ -3,6 +3,8 @@
 
 
 
+.. _oracle-how-to-index:
+
 How-to guides
 =============
 
@@ -13,26 +15,26 @@ Using Ubuntu images on Oracle Cloud
 -----------------------------------
 You can use Ubuntu images on Oracle Cloud to deploy virtual machines (VMs) or Oracle Kubernetes Engine (OKE) nodes.
 
-* :doc:`Find Ubuntu images <find-ubuntu-images>`
-* :doc:`Deploy Ubuntu OKE nodes using Oracle Cloud Console <deploy-ubuntu-oke-nodes-using-console>`
-* :doc:`Deploy Ubuntu OKE nodes using CLI <deploy-ubuntu-oke-nodes-using-cli>`
-* :doc:`Deploy Ubuntu OKE nodes using Terraform <deploy-ubuntu-oke-nodes-using-terraform>`
+* :ref:`Find Ubuntu images <find-ubuntu-images>`
+* :ref:`Deploy Ubuntu OKE nodes using Oracle Cloud Console <deploy-ubuntu-oke-nodes-using-console>`
+* :ref:`Deploy Ubuntu OKE nodes using CLI <deploy-ubuntu-oke-nodes-using-cli>`
+* :ref:`Deploy Ubuntu OKE nodes using Terraform <deploy-ubuntu-oke-nodes-using-terraform>`
 
 Enabling security features
 --------------------------
 Enable security features such as full-disk encryption and confidential computing, or use a bastion to access your VM.
 
-* :doc:`use-fde`
-* :doc:`enable-confidential-computing`
-* :doc:`Use a bastion for access <use-bastion-to-access-VM>`
+* :ref:`use-fde`
+* :ref:`enable-confidential-computing`
+* :ref:`Use a bastion for access <use-bastion-to-access-VM>`
 
 
 Performing upgrades
 -------------------
 Upgrade from one LTS version of Ubuntu to another.
 
-* :doc:`upgrade-from-focal-to-jammy`
-* :doc:`upgrade-from-jammy-to-noble`
+* :ref:`upgrade-from-focal-to-jammy`
+* :ref:`upgrade-from-jammy-to-noble`
 
 
 .. toctree::

--- a/docs/oracle/oracle-how-to/upgrade-from-focal-to-jammy.rst
+++ b/docs/oracle/oracle-how-to/upgrade-from-focal-to-jammy.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description:  Learn how to upgrade Ubuntu from 20.04 to 22.04  on Oracle Cloud. Includes manual intervention steps and best practices.
 
+.. _upgrade-from-focal-to-jammy:
+
 Upgrade from Ubuntu 20.04 LTS (Focal) to 22.04 LTS (Jammy)
 ==========================================================
 

--- a/docs/oracle/oracle-how-to/upgrade-from-jammy-to-noble.rst
+++ b/docs/oracle/oracle-how-to/upgrade-from-jammy-to-noble.rst
@@ -2,6 +2,8 @@
    :description: Learn how to upgrade Ubuntu from 22.04 to 24.04  on Oracle Cloud. Includes manual intervention steps and best practices.
 
 
+.. _upgrade-from-jammy-to-noble:
+
 Upgrade from Ubuntu 22.04 LTS (Jammy) to 24.04 LTS (Noble)
 ==========================================================
 

--- a/docs/oracle/oracle-how-to/use-bastion-to-access-VM.rst
+++ b/docs/oracle/oracle-how-to/use-bastion-to-access-VM.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn how to use bastion to access VMs on Oracle Cloud, including steps for creating a bastion and accessing VMs securely without public IPs.
 
+.. _use-bastion-to-access-VM:
+
 Use a bastion to access your VM
 ===============================
 
@@ -63,7 +65,7 @@ You can create the policy using the console or the CLI.
 Install oracle-cloud-agent on the VM
 ------------------------------------
 
-If you are using the images created by Canonical and published by Oracle (as described in :doc:`find-ubuntu-images`), they already have the oracle-cloud-agent pre-installed by default, and no additional action is necessary.
+If you are using the images created by Canonical and published by Oracle (as described in :ref:`find-ubuntu-images`), they already have the oracle-cloud-agent pre-installed by default, and no additional action is necessary.
 
 To check if the agent is installed, run:
 

--- a/docs/oracle/oracle-how-to/use-fde.rst
+++ b/docs/oracle/oracle-how-to/use-fde.rst
@@ -2,6 +2,8 @@
    :description: Learn how to create an instance on Oracle Cloud with personalized full-disk encryption (FDE).
 
 
+.. _use-fde:
+
 Use full-disk encryption (FDE)
 ==============================
 

--- a/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
+++ b/docs/oracle/oracle-reference/ubuntu-availability-on-oke.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Learn about the specific Ubuntu images available on OKE worker nodes for different OKE versions. 
 
+.. _ubuntu-availability-on-oke:
+
 Ubuntu Availability on OKE
 ==========================
 
@@ -66,8 +68,8 @@ Related how-to guides
 
 For step-by-step instructions on deploying Ubuntu nodes on OKE, see:
 
-- :doc:`Deploy Ubuntu OKE nodes using Oracle Cloud Console <../oracle-how-to/deploy-ubuntu-oke-nodes-using-console>`
-- :doc:`Deploy Ubuntu OKE nodes using CLI <../oracle-how-to/deploy-ubuntu-oke-nodes-using-cli>`
-- :doc:`Deploy Ubuntu OKE nodes using Terraform <../oracle-how-to/deploy-ubuntu-oke-nodes-using-terraform>`
+- :ref:`Deploy Ubuntu OKE nodes using Oracle Cloud Console <deploy-ubuntu-oke-nodes-using-console>`
+- :ref:`Deploy Ubuntu OKE nodes using CLI <deploy-ubuntu-oke-nodes-using-cli>`
+- :ref:`Deploy Ubuntu OKE nodes using Terraform <deploy-ubuntu-oke-nodes-using-terraform>`
 
 .. _`Policy`: https://cloud.oracle.com/identity/domains/policies

--- a/docs/public-images/index.rst
+++ b/docs/public-images/index.rst
@@ -2,6 +2,8 @@
    :description: Discover details about the publicly available Ubuntu cloud images, including LXD, OpenStack, Vagrant, QCOW and Buildd images.
 
 
+.. _index:
+
 Ubuntu Public Images
 ====================
 
@@ -23,13 +25,13 @@ In this documentation
     :header-rows: 0
 
     * - **Canonical's offerings**
-      - :doc:`Ubuntu cloud image artifacts <public-images-reference/artifacts>` • :doc:`LXD and OpenStack images <public-images-explanation/lxd-openstack-images>` • :doc:`Vagrant boxes <public-images-explanation/vagrant>` • :doc:`Buildd images <public-images-explanation/buildd>` 
+      - :ref:`Ubuntu cloud image artifacts <uci-artifacts>` • :ref:`LXD and OpenStack images <lxd-openstack-images>` • :ref:`Vagrant boxes <vagrant-explanation>` • :ref:`Buildd images <buildd>` 
       
     * - **Building and launching images**
-      - :doc:`Build a Vagrant box with Bartender <public-images-how-to/build-vagrant-with-bartender>` • :doc:`Run a Vagrant box <public-images-how-to/run-a-vagrant-box>` • :doc:`Launch QCOW images using libvirt <public-images-how-to/launch-with-libvirt>` • :doc:`Launch QCOW images using QEMU <public-images-how-to/launch-qcow-with-qemu>`  • :doc:`Run an OVA using VirtualBox <public-images-how-to/run-an-ova-using-virtualbox>`  • :doc:`Create and use a local cloud-init datasource <public-images-how-to/use-local-cloud-init-ds>`  • :doc:`Verify an image checksum <public-images-how-to/verify-image-checksum>` 
+      - :ref:`Build a Vagrant box with Bartender <vagrant-bartender>` • :ref:`Run a Vagrant box <run-a-vagrant-box>` • :ref:`Launch QCOW images using libvirt <launch-libvirt>` • :ref:`Launch QCOW images using QEMU <qcow-qemu>`  • :ref:`Run an OVA using VirtualBox <run-an-ova-using-virtualbox>`  • :ref:`Create and use a local cloud-init datasource <use-local-cloud-init-ds>`  • :ref:`Verify an image checksum <verify-image-checksum>` 
       
     * - **Policies**
-      - :doc:`Security overview <public-images-explanation/ubuntu-security-on-public-images>` • :doc:`Image retention policy <public-images-explanation/public-image-retention-policy>` 
+      - :ref:`Security overview <ubuntu-security-on-public-images>` • :ref:`Image retention policy <public-image-retention-policy>` 
       
 
 How this documentation is organized
@@ -37,9 +39,9 @@ How this documentation is organized
 
 This documentation uses the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
-* :doc:`How-to guides  <public-images-how-to/index>` assume you have basic familiarity with Ubuntu images on public clouds and want to achieve specific goals. They are instructions covering key operations and common tasks involving different types of public Ubuntu cloud images.
+* :ref:`How-to guides <public-images-how-to>` assume you have basic familiarity with Ubuntu images on public clouds and want to achieve specific goals. They are instructions covering key operations and common tasks involving different types of public Ubuntu cloud images.
 
-* :doc:`Explanation <public-images-explanation/index>` includes topic overviews, background and context and detailed discussion. These include key topics, such as the different types of images that we build and support, security aspects and our image retention policy.
+* :ref:`Explanation <public-images-explanation>` includes topic overviews, background and context and detailed discussion. These include key topics, such as the different types of images that we build and support, security aspects and our image retention policy.
 
 ---------
 

--- a/docs/public-images/public-images-explanation/lxd-openstack-images.rst
+++ b/docs/public-images/public-images-explanation/lxd-openstack-images.rst
@@ -29,7 +29,7 @@ Canonical provides cloud image artifacts on
 `cloud-images.ubuntu.com`_ that have
 been customized to run on public clouds, including LXD and OpenStack. To
 learn more about these artifacts and supported architectures, visit our
-Ubuntu :doc:`cloud image artifacts <../public-images-reference/artifacts>`
+Ubuntu :ref:`cloud image artifacts <uci-artifacts>`
 documentation.
 
 Supported Architectures

--- a/docs/public-images/public-images-explanation/public-image-retention-policy.rst
+++ b/docs/public-images/public-images-explanation/public-image-retention-policy.rst
@@ -20,7 +20,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`.
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`.
 
 The retention policy can be summarized as follows:
 

--- a/docs/public-images/public-images-how-to/launch-with-libvirt.rst
+++ b/docs/public-images/public-images-how-to/launch-with-libvirt.rst
@@ -25,7 +25,7 @@ Since we are dealing with cloud images here, we'll need a cloud-init user-data f
 Find and download an image
 --------------------------
 
-Ubuntu cloud images are hosted on https://cloud-images.ubuntu.com/. Refer to :doc:`../public-images-reference/artifacts` for a description of the various image types found there.
+Ubuntu cloud images are hosted on https://cloud-images.ubuntu.com/. Refer to :ref:`uci-artifacts` for a description of the various image types found there.
 
 QCOW images (``.img``) are suitable for use with libvirt and the QEMU driver. Once you have identified a suitable image, download it. For example, the following would download the current daily Ubuntu 24.04 (noble) image for AMD64 machines:
 

--- a/docs/public-images/public-images-reference/artifacts.rst
+++ b/docs/public-images/public-images-reference/artifacts.rst
@@ -9,7 +9,7 @@ This document provides detailed information on various Ubuntu cloud image artifa
 
 .. note::
 
-  If you are looking for Ubuntu images to use on the major public clouds, their documentation can be found at: :doc:`Ubuntu on AWS <aws:index>`, :doc:`Ubuntu on Azure <azure:index>`, :doc:`Ubuntu on GCP <google:index>`, :doc:`Ubuntu on IBM <ibm:index>` and :doc:`Ubuntu on Oracle <oracle:index>`.
+  If you are looking for Ubuntu images to use on the major public clouds, their documentation can be found at: :ref:`Ubuntu on AWS <aws:index>`, :ref:`Ubuntu on Azure <azure:index>`, :ref:`Ubuntu on GCP <google:index>`, :ref:`Ubuntu on IBM <ibm:index>` and :ref:`Ubuntu on Oracle <oracle:index>`.
 
 Images
 ------

--- a/docs/reuse/OKE-nodes.txt
+++ b/docs/reuse/OKE-nodes.txt
@@ -4,7 +4,7 @@
 
 Start: Intro and prereqs
 
-Ubuntu images are available for OKE worker nodes, with support for a select number of suites and Kubernetes versions. For a list of supported OKE configurations, see our :doc:`Ubuntu availability on OKE </oracle-reference/ubuntu-availability-on-oke>` page.
+Ubuntu images are available for OKE worker nodes, with support for a select number of suites and Kubernetes versions. For a list of supported OKE configurations, see our :ref:`Ubuntu availability on OKE <ubuntu-availability-on-oke>` page.
 
 Prerequisites
 -------------

--- a/docs/vmware/index.rst
+++ b/docs/vmware/index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Discover Ubuntu on VMware, including a dashboard for detecting CVE vulnerabilities on VMware workloads.
 
+.. _index:
+
 Ubuntu on VMware
 ================
 
@@ -20,7 +22,7 @@ and features needed to run specific workloads.
 How this documentation is organized
 ------------------------------------
 
-This documentation is currently minimal and includes information about :doc:`finding CVE vulnerabilities <vmware-reference/vcf-cve-dashboard>` on active Ubuntu on VMware images. We'll be updating it with more content in the future, including how-to guides and other reference material for running Ubuntu on VMware. At that point, the documentation will use the `Diátaxis documentation structure <https://diataxis.fr/>`__.
+This documentation is currently minimal and includes information about :ref:`finding CVE vulnerabilities <vcf-cve-dashboard>` on active Ubuntu on VMware images. We'll be updating it with more content in the future, including how-to guides and other reference material for running Ubuntu on VMware. At that point, the documentation will use the `Diátaxis documentation structure <https://diataxis.fr/>`__.
 
 ---------
 
@@ -37,7 +39,7 @@ Get involved
 * `Get support`_
 * `Join our online chat`_
 * `Discuss on Matrix`_
-* :doc:`vmware-how-to/contribute-to-these-docs`
+* :ref:`contribute-to-these-docs`
 
 Governance and policies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/vmware/vmware-how-to/configure-your-vm.rst
+++ b/docs/vmware/vmware-how-to/configure-your-vm.rst
@@ -2,6 +2,8 @@
    :description: How to configure an Ubuntu VM using OVF template variables when deploying an OVA on VMware.
 
 
+.. _configure-your-vm:
+
 Configure your VM using template variables
 ==========================================
 

--- a/docs/vmware/vmware-how-to/contribute-to-these-docs.rst
+++ b/docs/vmware/vmware-how-to/contribute-to-these-docs.rst
@@ -2,6 +2,8 @@
    :description: Learn how to contribute to Ubuntu on VMware documentation, including editing, building, and submitting pull requests.
 
 
+.. _contribute-to-these-docs:
+
 Contribute to these docs
 ========================
 

--- a/docs/vmware/vmware-reference/vcf-cve-dashboard.rst
+++ b/docs/vmware/vmware-reference/vcf-cve-dashboard.rst
@@ -1,3 +1,5 @@
+.. _vcf-cve-dashboard:
+
 VCF CVE Dashboard
 -----------------
 


### PR DESCRIPTION
Closes canonical/open-documentation-academy#371

Replaces `:doc:` references with `:ref:` throughout the documentation so internal links rely on stable labels rather than filenames.

### Changes

* Added explicit `.. _label:` anchors to target pages.
* Updated same-project references to use local `:ref:` labels.
* Preserved `project:label` prefixes for cross-project references.
* Left `docs/doc-cheat-sheet.rst` unchanged since its `:doc:` references are syntax examples.

### Testing

* Built all 9 Sphinx sub-projects independently using `PROJECT=<name> sphinx-build -b dirhtml docs <out>`.
* All projects build successfully.
* Verified that all cross-project target labels introduced by this PR are correctly defined.

### Note

Cross-project references may produce temporary warnings because the 9 projects are built independently. Since Read the Docs uses `fail_on_warning: true`, all projects need to rebuild once after merge before those references resolve cleanly.