### PR TITLE
Reintroduce cross-project :ref: links (step 2/2)

### DIFF
--- a/docs/all-clouds/index.rst
+++ b/docs/all-clouds/index.rst
@@ -29,12 +29,12 @@ For further details, refer to the cloud-specific documentation:
 ..  grid:: 1 1 2 2
    :padding: 0
 
-   .. grid-item-card:: :doc:`Ubuntu on AWS <aws:index>`   
-   .. grid-item-card:: :doc:`Ubuntu on Azure <azure:index>`  
-   .. grid-item-card:: :doc:`Ubuntu on GCP <google:index>` 
-   .. grid-item-card:: :doc:`Ubuntu on IBM <ibm:index>`
-   .. grid-item-card:: :doc:`Ubuntu on Oracle <oracle:index>`
-   .. grid-item-card:: :doc:`Ubuntu on VMware <vmware:index>`
+   .. grid-item-card:: :ref:`Ubuntu on AWS <aws:index>`   
+   .. grid-item-card:: :ref:`Ubuntu on Azure <azure:index>`  
+   .. grid-item-card:: :ref:`Ubuntu on GCP <google:index>` 
+   .. grid-item-card:: :ref:`Ubuntu on IBM <ibm:index>`
+   .. grid-item-card:: :ref:`Ubuntu on Oracle <oracle:index>`
+   .. grid-item-card:: :ref:`Ubuntu on VMware <vmware:index>`
 
 -----------------------------------------------------------------
 
@@ -48,8 +48,8 @@ Apart from the specific public clouds, Canonical also produces a variety of Ubun
 ..  grid:: 1 1 2 2
    :padding: 0
 
-   .. grid-item-card:: :doc:`Ubuntu on OCI container registries <oci:index>`
-   .. grid-item-card:: :doc:`Ubuntu Public Images <public-images:index>`
+   .. grid-item-card:: :ref:`Ubuntu on OCI container registries <oci:index>`
+   .. grid-item-card:: :ref:`Ubuntu Public Images <public-images:index>`
 
 
 

--- a/docs/aws/aws-explanation/aws-image-testing.rst
+++ b/docs/aws/aws-explanation/aws-image-testing.rst
@@ -14,7 +14,7 @@ We run **Canonical's own internal test suite** on each daily EC2 image. This sui
 Testing in the image life-cycle
 -------------------------------
 
-Ubuntu images on AWS move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :doc:`image release types <all-clouds:all-clouds-explanation/release-types>` and the :doc:`EC2 image retention policy <ec2-image-retention-policy>`.)
+Ubuntu images on AWS move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :ref:`image release types <all-clouds:release-types>` and the :ref:`EC2 image retention policy <ec2-image-retention-policy>`.)
 
 New images are built daily from the latest packages. Each daily build is uploaded and then exercised by the tests described below.
 

--- a/docs/aws/aws-explanation/ec2-image-retention-policy.rst
+++ b/docs/aws/aws-explanation/ec2-image-retention-policy.rst
@@ -22,7 +22,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`, and to get a list of these images on AWS, refer to: :doc:`../aws-how-to/instances/find-ubuntu-images`. In general, daily images are deleted, and release images are deprecated. Each image type is retained for a defined period, with a minimum number of recent images always preserved.
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`, and to get a list of these images on AWS, refer to: :ref:`find-ubuntu-images`. In general, daily images are deleted, and release images are deprecated. Each image type is retained for a defined period, with a minimum number of recent images always preserved.
 
 The retention policy can be summarized as follows:
 

--- a/docs/aws/aws-explanation/eks-snaps.rst
+++ b/docs/aws/aws-explanation/eks-snaps.rst
@@ -29,4 +29,4 @@ Snaps
      - `aws-credential-provider <https://github.com/kubernetes/cloud-provider-aws/tree/master?tab=readme-ov-file#aws-credential-provider>`_, which provides credentials for allowing a k8s cluster to pull container images from ECR
      - EKS 1.28
 
-For deploying Ubuntu Pro containers on Kubernetes clusters, see :doc:`Deploy Ubuntu Pro containers on Kubernetes <oci:oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster>`.
+For deploying Ubuntu Pro containers on Kubernetes clusters, see :ref:`Deploy Ubuntu Pro containers on Kubernetes <oci:how-to-deploy-pro-container-on-pro-cluster>`.

--- a/docs/aws/aws-explanation/ubuntu-security-on-aws.rst
+++ b/docs/aws/aws-explanation/ubuntu-security-on-aws.rst
@@ -12,7 +12,7 @@ Ubuntu images on AWS include the security features provided by both Ubuntu and A
 Ubuntu security features
 ------------------------
 
-Ubuntu on AWS provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to Ubuntu server's `Introductory page on security`_.
+Ubuntu on AWS provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to Ubuntu server's `Introductory page on security`_.
 
 
 AWS security features

--- a/docs/aws/aws-how-to/instances/build-pro-ami-using-packer.rst
+++ b/docs/aws/aws-how-to/instances/build-pro-ami-using-packer.rst
@@ -15,7 +15,7 @@ We'll be using Ubuntu Pro 24.04 LTS for this guide, but the method is equally ap
    * For **Ubuntu Pro FIPS**, it is better to use a pre-enabled FIPS image from the Marketplace to avoid unnecessary additional steps. 
    * For **Ubuntu LTS**, you can use this method with a small change as explained at the end of the :ref:`define-provisioners` section below. 
    * For **Ubuntu 22.04 LTS and above** you need Packer version 1.8.1 or newer.
-   * For an overview of Ubuntu image types, see :doc:`Ubuntu base and minimal images <all-clouds:all-clouds-explanation/ubuntu-base-and-minimal-images>`.
+   * For an overview of Ubuntu image types, see :ref:`Ubuntu base and minimal images <all-clouds:ubuntu-base-and-minimal-images>`.
 
 Basic setup
 -------------

--- a/docs/aws/aws-how-to/instances/cis-hardening.rst
+++ b/docs/aws/aws-how-to/instances/cis-hardening.rst
@@ -348,7 +348,7 @@ If passwords are enabled, follow the instructions in the
 CIS 5.1.1 - Ensure permissions on /etc/ssh/sshd_config are configured
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The USG remediation sets permissions on ``/etc/ssh/sshd_config`` itself but leaves files
-inside ``/etc/ssh/sshd_config.d/`` unchanged. Files added by :doc:`cloud-init <public-images:public-images-how-to/use-local-cloud-init-ds>` or other tooling
+inside ``/etc/ssh/sshd_config.d/`` unchanged. Files added by :ref:`cloud-init <public-images:use-local-cloud-init-ds>` or other tooling
 after remediation may not have ``0600`` permissions. Check and correct manually if needed::
 
    sudo chmod 0600 /etc/ssh/sshd_config.d/*

--- a/docs/aws/aws-how-to/instances/import-local-vm-to-aws.rst
+++ b/docs/aws/aws-how-to/instances/import-local-vm-to-aws.rst
@@ -22,7 +22,7 @@ Requirements
         
         ``sudo qemu-img convert -O raw /var/lib/libvirt/images/my-machine.qcow2 my-machine.raw``
     
-        For more about LXD and OpenStack Ubuntu images, see :doc:`LXD/OpenStack images <public-images:public-images-explanation/lxd-openstack-images>`.
+        For more about LXD and OpenStack Ubuntu images, see :ref:`LXD/OpenStack images <public-images:lxd-openstack-images>`.
 
 
 Upload your OVA machine image to S3
@@ -126,7 +126,7 @@ Get the VM image ready for production
 -------------------------------------
 
 The VM image is almost ready to be used at scale on AWS. The last step is to allow cloud-init to reinitialize the machine ID. This ensures that each instance launched from this image will generate its own machine ID and will re-detect the cloud that it is running on so that certain features specific to AWS can be enabled. This is also needed if you’re planning to upgrade to Ubuntu Pro in the future.
-For using cloud-init with a local data source, see :doc:`Use a local cloud-init data source <public-images:public-images-how-to/use-local-cloud-init-ds>`.
+For using cloud-init with a local data source, see :ref:`Use a local cloud-init data source <public-images:use-local-cloud-init-ds>`.
 
 Run:
 

--- a/docs/aws/aws-how-to/instances/index.rst
+++ b/docs/aws/aws-how-to/instances/index.rst
@@ -11,7 +11,7 @@ These how-to guides relate to launching and using Ubuntu-based EC2 instances. Th
 Finding images and launching instances
 --------------------------------------
 
-Guides to help you find the right Ubuntu image for your use case and launch different types of EC2 instances, including desktops, :doc:`confidential computing <all-clouds:all-clouds-explanation/confidential-computing>` instances, local VMs and hardened instances.
+Guides to help you find the right Ubuntu image for your use case and launch different types of EC2 instances, including desktops, :ref:`confidential computing <all-clouds:confidential-computing>` instances, local VMs and hardened instances.
 
 * :ref:`Launch an instance using CLI <launch-ubuntu-ec2-instance>`
 * :ref:`Find images <find-ubuntu-images>`

--- a/docs/aws/aws-how-to/instances/install-nvidia-drivers.rst
+++ b/docs/aws/aws-how-to/instances/install-nvidia-drivers.rst
@@ -12,7 +12,7 @@ AWS provides GPU-enabled instance types for workloads that require GPU compute p
 
 For more comprehensive instructions on checking the available drivers and installing the correct one based on different use-cases, refer to the `Ubuntu server documentation for installing NVIDIA drivers`_.
 
-To test proposed NVIDIA driver versions before release, see :doc:`all-clouds:all-clouds-how-to/install-proposed-nvidia-drivers-for-testing`.
+To test proposed NVIDIA driver versions before release, see :ref:`all-clouds:install-proposed-nvidia-drivers-for-testing`.
 
 Launch your instance
 --------------------

--- a/docs/aws/aws-how-to/instances/launch-and-attest-amd-sev-snp-instances.rst
+++ b/docs/aws/aws-how-to/instances/launch-and-attest-amd-sev-snp-instances.rst
@@ -6,7 +6,7 @@
 Launch and attest AMD SEV-SNP instances with Ubuntu 24.04 on AWS
 ================================================================
 
-Amazon EC2 now supports AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SEV-SNP), on M6a, C6a, and R6a instance types in certain regions. These instances, when used with Ubuntu 24.04 LTS, allow customers to leverage AMD's confidential computing capabilities (:doc:`overview <all-clouds:all-clouds-explanation/confidential-computing>`) on AWS.
+Amazon EC2 now supports AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SEV-SNP), on M6a, C6a, and R6a instance types in certain regions. These instances, when used with Ubuntu 24.04 LTS, allow customers to leverage AMD's confidential computing capabilities (:ref:`overview <all-clouds:confidential-computing>`) on AWS.
 
 This guide covers the steps needed to launch, test and validate the AMD SEV-SNP capabilities on AWS. The steps have been tested with Ubuntu 24.04 LTS and Ubuntu Pro 24.04 LTS on us-east-2.
 

--- a/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-fips-cluster.rst
+++ b/docs/aws/aws-how-to/kubernetes/deploy-ubuntu-pro-fips-cluster.rst
@@ -11,7 +11,7 @@ This guide will walk you through the steps needed to get an EKS cluster of FIPS-
 
 The process involves creating your custom EKS FIPS AMI using Packer, and then deploying it using ``eksctl``. To test and take a peek inside the cluster, ``kubectl`` can be used.
 
-For non-FIPS clusters, see :doc:`deploy-ubuntu-cluster-with-eks-ami` or :doc:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`. For FIPS on OCI containers, see :doc:`FIPS Ubuntu container <oci:oci-tutorials/fips-ubuntu-container>`.
+For non-FIPS clusters, see :ref:`deploy-ubuntu-cluster-with-eks-ami` or :ref:`deploy-ubuntu-pro-cluster-with-eks-pro-ami`. For FIPS on OCI containers, see :ref:`FIPS Ubuntu container <oci:how-to-fips-ubuntu-container>`.
 
 
 Prerequisites

--- a/docs/azure/azure-explanation/canonical-offerings.rst
+++ b/docs/azure/azure-explanation/canonical-offerings.rst
@@ -14,7 +14,7 @@ Ubuntu images are specifically fine-tuned to maximize performance on Azure infra
 
 * `Server images`_ are general-purpose images customized for Azure Virtual Machines. These images are also available with `Ubuntu Pro`_ enabled.
 
-* :doc:`Minimal images <all-clouds:all-clouds-explanation/ubuntu-base-and-minimal-images>` are designed for automated deployment at scale with a reduced default package set. Things like interactive usage tools are omitted. They are much smaller, boot faster, and require fewer security updates over time due to the fewer installed packages. These images are also available with `Ubuntu Pro`_ enabled.
+* :ref:`Minimal images <all-clouds:ubuntu-base-and-minimal-images>` are designed for automated deployment at scale with a reduced default package set. Things like interactive usage tools are omitted. They are much smaller, boot faster, and require fewer security updates over time due to the fewer installed packages. These images are also available with `Ubuntu Pro`_ enabled.
 
 *  :ref:`Confidential Virtual Machine (CVM) images <azure-cvms>` provide enhanced security features designed to protect data at rest, in use, and during boot. CVM images are intended for use with Azure's confidential computing capabilities using hardware-enabled security features. These images are also available with `Ubuntu Pro`_ enabled.
 

--- a/docs/azure/azure-explanation/image-retention-policy.rst
+++ b/docs/azure/azure-explanation/image-retention-policy.rst
@@ -10,7 +10,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`. 
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`. 
 
 On Azure, *release* and *daily* images for a given Ubuntu release are published under two distinct offers. To avoid confusion, only *release* images of Ubuntu are displayed on the Azure Marketplace and *daily* images are 'hidden'.
 

--- a/docs/azure/azure-explanation/security-overview.rst
+++ b/docs/azure/azure-explanation/security-overview.rst
@@ -11,7 +11,7 @@ Ubuntu images on Azure include the security features provided by both Ubuntu and
 Ubuntu security features
 ------------------------
 
-Ubuntu on Azure inherits and benefits from all of the security features available to Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on Azure inherits and benefits from all of the security features available to Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 Azure security features
 -----------------------

--- a/docs/google/google-explanation/gce-image-retention-policy.rst
+++ b/docs/google/google-explanation/gce-image-retention-policy.rst
@@ -20,7 +20,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`, and to get a list of these images on GCP, refer to: :doc:`../google-how-to/gce/find-ubuntu-images`.
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`, and to get a list of these images on GCP, refer to: :ref:`find-ubuntu-images`.
 
 The retention policy can be summarized as follows:
 

--- a/docs/google/google-explanation/gce-image-testing.rst
+++ b/docs/google/google-explanation/gce-image-testing.rst
@@ -17,7 +17,7 @@ We run two sets of automated tests on each daily GCE image:
 Testing in the image life-cycle
 -------------------------------
 
-Ubuntu images on GCE move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :doc:`image release types <all-clouds:all-clouds-explanation/release-types>` and the :doc:`GCE image retention policy <gce-image-retention-policy>`.)
+Ubuntu images on GCE move through a life-cycle of *daily* builds that may be promoted to *release* images. (For background on these image types, see :ref:`image release types <all-clouds:release-types>` and the :ref:`GCE image retention policy <gce-image-retention-policy>`.)
 
 New images are built daily from the latest packages. Each daily build is uploaded and then exercised by the two sets of tests described below.
 

--- a/docs/google/google-explanation/security-overview.rst
+++ b/docs/google/google-explanation/security-overview.rst
@@ -12,7 +12,7 @@ Ubuntu images on Google Cloud include the security features provided by both Ubu
 Ubuntu security features
 ------------------------
 
-Ubuntu on GCP provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on GCP provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 
 GCP security features

--- a/docs/ibm/ibm-explanation/security-overview.rst
+++ b/docs/ibm/ibm-explanation/security-overview.rst
@@ -12,7 +12,7 @@ Ubuntu images on IBM Cloud include the security features provided by both Ubuntu
 Ubuntu security features
 ------------------------
 
-Ubuntu on IBM provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on IBM provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 
 IBM Cloud security features

--- a/docs/oci/oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster.rst
+++ b/docs/oci/oci-how-to/deploy-pro-container-on-pro-kubernetes-cluster.rst
@@ -28,12 +28,12 @@ Deploying Pro Kubernetes clusters in various clouds
 
 	.. tab:: EKS
 
-		Check out :doc:`aws:aws-how-to/kubernetes/deploy-ubuntu-pro-cluster` to learn
+		Check out :ref:`aws:deploy-ubuntu-pro-cluster` to learn
 		how to deploy an Ubuntu Pro Kubernetes cluster on Elastic Kubernetes Service (EKS).
 
 	.. tab:: GCE
 
-		Check out :doc:`google:google-how-to/gke/deploy-kubernetes-with-ubuntu-pro` to learn
+		Check out :ref:`google:deploy-kubernetes-with-ubuntu-pro` to learn
 		how to deploy an Ubuntu Pro Kubernetes cluster on Google Compute Engine (GCE).
 
 	.. tab:: OpenShift

--- a/docs/oracle/oracle-explanation/security-overview.rst
+++ b/docs/oracle/oracle-explanation/security-overview.rst
@@ -11,7 +11,7 @@ Ubuntu images on Oracle Cloud include the security features provided by both Ubu
 Ubuntu security features
 ------------------------
 
-Ubuntu on Oracle provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :doc:`Security in the Ubuntu cloud images <all-clouds:all-clouds-explanation/security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
+Ubuntu on Oracle provides all the security features available on Ubuntu Server. A detailed description of these features can be found on the `Ubuntu security page`_ and in our explanation about :ref:`Security in the Ubuntu cloud images <all-clouds:security-overview>`. For further guidance on usage refer to  Ubuntu server's `Introductory page on security`_. 
 
 
 Oracle Cloud security features

--- a/docs/oracle/oracle-how-to/enable-confidential-computing.rst
+++ b/docs/oracle/oracle-how-to/enable-confidential-computing.rst
@@ -144,7 +144,7 @@ For more information about creating confidential computing enabled instances, re
 * `Protect data in use with OCI confidential computing <https://blogs.oracle.com/cloud-infrastructure/protect-data-in-use-with-confidential-computing>`_
 * `Confidential computing <https://docs.oracle.com/en-us/iaas/Content/Compute/References/confidential_compute.htm>`_
 
-For a general overview of confidential computing technologies, see :doc:`all-clouds:all-clouds-explanation/confidential-computing`.
+For a general overview of confidential computing technologies, see :ref:`all-clouds:confidential-computing`.
 
 .. _`AMD documentation`: https://www.amd.com/en/developer/sev.html
 .. _`Shapes that support confidential computing`: https://docs.oracle.com/en-us/iaas/Content/Compute/References/confidential_compute.htm#confidential_compute__coco_supported_shapes

--- a/docs/public-images/public-images-explanation/public-image-retention-policy.rst
+++ b/docs/public-images/public-images-explanation/public-image-retention-policy.rst
@@ -20,7 +20,7 @@ Image retention policy
    :start-after: Start: Daily vs release images
    :end-before: End: Daily vs release images
 
-For more details about these image types, check out our documentation of :doc:`image release types <all-clouds:all-clouds-explanation/release-types>`.
+For more details about these image types, check out our documentation of :ref:`image release types <all-clouds:release-types>`.
 
 The retention policy can be summarized as follows:
 

--- a/docs/public-images/public-images-reference/artifacts.rst
+++ b/docs/public-images/public-images-reference/artifacts.rst
@@ -9,7 +9,7 @@ This document provides detailed information on various Ubuntu cloud image artifa
 
 .. note::
 
-  If you are looking for Ubuntu images to use on the major public clouds, their documentation can be found at: :doc:`Ubuntu on AWS <aws:index>`, :doc:`Ubuntu on Azure <azure:index>`, :doc:`Ubuntu on GCP <google:index>`, :doc:`Ubuntu on IBM <ibm:index>` and :doc:`Ubuntu on Oracle <oracle:index>`.
+  If you are looking for Ubuntu images to use on the major public clouds, their documentation can be found at: :ref:`Ubuntu on AWS <aws:index>`, :ref:`Ubuntu on Azure <azure:index>`, :ref:`Ubuntu on GCP <google:index>`, :ref:`Ubuntu on IBM <ibm:index>` and :ref:`Ubuntu on Oracle <oracle:index>`.
 
 Images
 ------


### PR DESCRIPTION
Follow-up to #553 and #554.

Now that #554 has merged and all sub-project sites have republished with the new labels live, this PR restores the 33 cross-project `:ref:` references (`aws:`, `azure:`, `google:`, `ibm:`, `oracle:`, `oci:`, `public-images:`, `vmware:`, `all-clouds:`) that were temporarily reverted to `:doc:` in #554.

### Testing

Verified against the live intersphinx inventories that all referenced labels now exist, and rebuilt all 8 affected sub-projects with `--fail-on-warning --keep-going`. All pass with zero warnings.