### PR TITLE
docs(conf): replace blanket anchor-URL ignore with targeted domain exceptions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,7 +137,6 @@ html_theme_options = {
 linkcheck_ignore = [
     "http://127.0.0.1:8000",
     'http://localhost:8000',
-    r'.*#.*',
     "https://github.com",
     r"https://matrix\.to/.*",
     "https://example.com",
@@ -146,8 +145,37 @@ linkcheck_ignore = [
     "https://www.cloudsigma.com"
 ]
 
-# A regex list of URLs where anchors are ignored by 'make linkcheck'
-linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
+# A regex list of URLs where anchors are ignored by 'make linkcheck'.
+# The base URL is still checked for reachability; only the in-page anchor
+# match is skipped. Domains are listed here (instead of blanket-ignoring
+# every URL that contains a '#') because they either render their
+# anchors/headings client-side with JavaScript (so the static HTML
+# linkcheck fetches never contains the target id) or serve inconsistent
+# markup that intermittently defeats Python's HTML parser, causing false
+# "Anchor not found" reports even though the link works for readers.
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/.*",
+    # ubuntu.com injects in-page section anchors client-side
+    r"https://ubuntu\.com/.*",
+    # Azure Portal "create" links are client-side SPA routes, not HTML anchors
+    r"https://portal\.azure\.(com|cn)/.*",
+    # AWS Console is a client-side SPA; '#/...' is a route, not an anchor
+    r"https://console\.aws\.amazon\.com/.*",
+    # AWS docs and the HashiCorp Developer site are JS-rendered; their
+    # heading ids either aren't in the static HTML or don't match the
+    # public URL fragment exactly (e.g. HashiCorp prefixes ids with
+    # "user-content-")
+    r"https://docs\.aws\.amazon\.com/.*",
+    r"https://developer\.hashicorp\.com/.*",
+    # docs.oracle.com renders reference-page anchors client-side
+    r"https://docs\.oracle\.com/.*",
+    # azure.microsoft.com marketing pages inject section anchors client-side
+    r"https://azure\.microsoft\.com/.*",
+    # cloud.ibm.com docs serve markup that reproducibly defeats the anchor
+    # parser (confirmed by running linkcheck against it directly), even
+    # though the anchors are present and the pages render fine for readers
+    r"https://cloud\.ibm\.com/.*",
+]
 
 # How long the link checker will wait for a response for each request
 # TODO: Decrease to improve run time or increase if links frequently time out.


### PR DESCRIPTION
## Summary

`linkcheck_ignore` contained `r'.*#.*'`, which skipped **every URL containing a `#`** — not just the anchor check, but the entire link, including whether the base URL was reachable.

This meant a genuinely dead link could silently pass `make linkcheck` as long as it contained a fragment.

This replaces the blanket ignore with targeted `linkcheck_anchors_ignore_for_url` entries (a Sphinx builtin, already used here for `github.com`) for the specific domains that produce false `Anchor not found` positives.

URLs are still checked for reachability; only the unreliable in-page anchor match is skipped.

## How the Domain List Was Built

I removed the blanket ignore locally and ran `make linkcheck` via `sphinx-build -b linkcheck` against every subproject in the repo:

* aws
* azure
* google
* oracle
* ibm
* oci
* vmware
* public-images
* all-clouds

For every link flagged as `[broken] ... Anchor 'x' not found`, I fetched the same URL and inspected the raw HTML received by the linkcheck builder to distinguish genuine breakage from false positives.

Every false positive fell into one of three categories:

* **Client-side rendered anchors** — `ubuntu.com`, `docs.aws.amazon.com`, `developer.hashicorp.com`, `docs.oracle.com`, and `azure.microsoft.com` inject heading IDs via JavaScript after page load. The static HTML fetched by Sphinx's linkcheck does not contain the target ID, even though the link works correctly for a real reader.

  * HashiCorp provided a useful confirmation: its rendered ID is `user-content-<slug>`, while the public URL fragment omits the `user-content-` prefix. Client-side JavaScript bridges the gap, but a static fetch cannot.

* **Client-side hash routing, not anchors at all** — `portal.azure.com` / `portal.azure.cn` (`#create/...`) and `console.aws.amazon.com` (`#/case/...`) use `#` for SPA routing. There is no server-rendered element for Sphinx to find.

* **Flaky parsing** — `cloud.ibm.com`: the anchor genuinely exists in the HTML, verified with plain `curl`, but I reproduced the failure twice using Sphinx's own `AnchorCheckParser` directly against the live response. Python's `html.parser` intermittently fails to find the anchor. This is worth raising with Sphinx upstream separately and is out of scope for this PR.

No genuinely broken link was found or newly masked by this change.

## Verification

Ran `make linkcheck` per subproject after the change:

* **aws, azure, google, oracle, ibm** — zero `Anchor not found` results remain.
* Remaining `[broken]` results across the repo are unrelated pre-existing issues (for example, `askubuntu.com` and a couple of Red Hat documentation URLs returning 403 to automated requests). These are not anchor-related and are not touched by this PR.